### PR TITLE
Fix undefined behavior in `black_box`

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -107,6 +107,7 @@ tempdir
 tempfile
 totalrw
 trybuild
+uninit
 xtleak
 xtree
 valgrind

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-# spell-checker:ignore taiki rustfmt binstall clippy taplo rustup
+# spell-checker:ignore taiki rustfmt binstall clippy taplo rustup miri
 
 name: Build and Check
 
@@ -146,6 +146,31 @@ jobs:
         with:
           name: iai-callgrind-benchmarks
           path: "target/iai"
+  miri:
+    needs: [format]
+    name: Tests/Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: miri_ubuntu-latest
+          cache-directories: /home/runner/.cache/miri
+      - name: Info
+        run: |
+          set -x
+          pwd
+          rustup --version
+          rustup show
+          rustup component list --installed
+          cargo --list
+      - name: Setup miri
+        run: cargo miri setup
+      - name: Test with miri
+        run: cargo miri test --package iai-callgrind
 
   docs:
     needs: [base]

--- a/iai-callgrind/src/lib.rs
+++ b/iai-callgrind/src/lib.rs
@@ -767,10 +767,6 @@ impl_traits!(Tool, internal::InternalTool);
 /// This variant is stable-compatible, but it may cause some performance overhead
 /// or fail to prevent code from being eliminated.
 pub fn black_box<T>(dummy: T) -> T {
-    // SAFETY: The safety conditions for read_volatile and forget are satisfied
-    unsafe {
-        let ret = std::ptr::read_volatile(&dummy);
-        std::mem::forget(dummy);
-        ret
-    }
+    // SAFETY: `dummy` and the returned value do not alias.
+    unsafe { std::mem::MaybeUninit::new(dummy).as_ptr().read_volatile() }
 }


### PR DESCRIPTION
The previous implementation allowed the output to alias the input. This would cause undefined behavior when passed `&mut` references.

`MaybeUninit::as_ptr` was introduced in 1.59, so this does not affect the 1.60 MSRV.