### PR TITLE
Add support for specifying multiple benchmarks within a single `benches` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   valgrind client requests. The client requests are available in the
   `iai-callgrind` package and can be activated via feature flags
   (`client_requests` and `client_requests_defs`).
+* ([#38](https://github.com/iai-callgrind/iai-callgrind/issues/38)): Add support
+  for specifying multiple library benchmarks in one go with the `#[benches]`
+  attribute. This attribute also accepts a `setup` argument which takes a path
+  to a function, so the `args` are passed as parameter to the `setup` function
+  instead of the benchmarking function.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ fn bench_fibonacci(value: u64) -> u64 {
 
 library_benchmark_group!(
     name = bench_fibonacci_group;
-    benchmarks = bench_fibonacci
+    benchmarks = bench_fibonacci, bench_fibonacci_alternative
 );
 
 main!(library_benchmark_groups = bench_fibonacci_group);
@@ -252,6 +252,46 @@ test_lib_bench_readme_example_fibonacci::bench_fibonacci_group::bench_fibonacci 
   Total read+write:        22025881|35638621        (-38.1966%) [-1.61803x]
   Estimated Cycles:        22025983|35638757        (-38.1965%) [-1.61803x]
 ```
+
+##### Specify multiple benchmarks at once with the #[benches] attribute
+
+Let's start with an example:
+
+```rust
+fn setup_worst_case_array(start: i32) -> Vec<i32> {
+    if start.is_negative() {
+        (start..0).rev().collect()
+    } else {
+        (0..start).rev().collect()
+    }
+}
+
+#[library_benchmark]
+#[benches::multiple(vec![1], vec![5])]
+#[benches::with_setup(args = [1, 5], setup = setup_worst_case_array)]
+fn bench_bubble_sort_with_benches_attribute(input: Vec<i32>) -> Vec<i32> {
+    black_box(bubble_sort(input))
+}
+```
+
+Usually the `arguments` are passed directly to the benchmarking function as it
+can be seen in the `#[benches::multiple(...)]` case. In
+`#[benches::with_setup(...)]`, the arguments are passed to the `setup` function
+instead. The above `#[library_benchmark]` is pretty much the same as
+
+```rust
+#[library_benchmark]
+#[bench::multiple_0(vec![1])]
+#[bench::multiple_1(vec![5])]
+#[bench::with_setup_0(setup_worst_case_array(1)])]
+#[bench::with_setup_1(setup_worst_case_array(5)])]
+fn bench_bubble_sort_with_benches_attribute(input: Vec<i32>) -> Vec<i32> {
+    black_box(bubble_sort(input))
+}
+```
+
+but a lot more concise especially if a lot of values are passed to the same
+`setup` function.
 
 ##### Examples
 
@@ -583,9 +623,9 @@ which would restore the default of `0` from valgrind.
 Mechanism](https://valgrind.org/docs/manual/manual-core-adv.html#manual-core-adv.clientreq).
 `iai-callgrind's` client requests have (compared to the valgrind's client
 requests used in `C` code) zero overhead on many targets which are also natively
-supported by valgrind. My opinion might be biased but, compared to other crates
-providing an interface to valgrind's client requests, `iai-callgrind` provides
-be the most complete and performant implementation.
+supported by valgrind. My opinion may be biased, but compared to other crates
+that offer an interface to valgrind's client requests, `iai-callgrind` provides
+the most complete and best performant implementation.
 
 Client requests are deactivated by default but can be activated with the
 `client_requests` feature.

--- a/benchmark-tests/benches/test_lib_bench_groups.rs
+++ b/benchmark-tests/benches/test_lib_bench_groups.rs
@@ -34,6 +34,11 @@ fn setup_best_case_array(start: i32) -> Vec<i32> {
     }
 }
 
+// TODO: REMOVE TESTING CODE
+fn setup_test(a: i32, b: i32) -> (i32, i32) {
+    (a + b, a - b)
+}
+
 // The #[library_benchmark] attribute let's you define a benchmark function which you can later use
 // in the `library_benchmark_groups!` macro. Just using the #[library_benchmark] attribute as a
 // standalone is fine for simple function calls without parameters. However, we actually want to
@@ -46,6 +51,19 @@ fn setup_best_case_array(start: i32) -> Vec<i32> {
 fn bench_bubble_sort_empty() -> Vec<i32> {
     // The `black_box` is needed to tell the compiler to not optimize what's inside the black_box or
     // else the benchmarks might return inaccurate results.
+    black_box(bubble_sort(black_box(vec![])))
+}
+
+// TODO: REMOVE TESTING CODE
+#[library_benchmark]
+// #[benches::my0((1, 2), (2, 3))]
+// #[benches::my1(args = [(1, 2), (2, 3)])]
+// #[benches::my0(args = [])]
+// #[benches::my1(args = [(1), (2,), [3], 5])]
+// #[benches::my1(args = [(1), (2,), [3], 5])]
+#[benches::my1(args = [(1, 2)], setup = setup_test)]
+// fn bench_bubble_sort_empty_testing(_c: i32, _d: i32) -> Vec<i32> {
+fn bench_bubble_sort_empty_testing((_c, _d): (i32, i32)) -> Vec<i32> {
     black_box(bubble_sort(black_box(vec![])))
 }
 
@@ -135,7 +153,10 @@ library_benchmark_group!(
         .regression(
             RegressionConfig::default().fail_fast(false)
         );
-    benchmarks = bench_bubble_sort_empty, bench_bubble_sort
+    benchmarks =
+        bench_bubble_sort_empty_testing,
+        bench_bubble_sort_empty,
+        bench_bubble_sort,
 );
 
 // In our example file here, we could have put `bench_fibonacci` into the same group as the bubble

--- a/benchmark-tests/benches/test_lib_bench_groups.rs
+++ b/benchmark-tests/benches/test_lib_bench_groups.rs
@@ -103,8 +103,7 @@ fn bench_bubble_sort_with_benches_attribute(input: Vec<i32>) -> Vec<i32> {
     black_box(bubble_sort(input))
 }
 
-// The same as above in `bench_bubble_sort_with_benches_attribute` but a function with multiple
-// parameters requires the elements to be specified as tuples.
+// A benchmarking function with multiple parameters requires the elements to be specified as tuples.
 #[library_benchmark]
 #[benches::multiple((1, 2), (3, 4))]
 #[benches::with_args(args = [(1, 2), (3, 4)])]
@@ -120,8 +119,8 @@ fn bench_fibonacci_with_config() -> u64 {
     black_box(black_box(fibonacci(black_box(8))))
 }
 
-// A config per `bench` attribute is also possible using the alternative `bench` attribute with
-// key = value pairs. The example below shows all accepted keys.
+// A `config` per `bench` or `benches` attribute is also possible using the alternative `bench`
+// or `benches` attribute with key = value pairs
 //
 // Note that `LibraryBenchmarkConfig` is additive for callgrind arguments, tools and environment
 // variables and appends them to the variables of `configs` of higher levels (like

--- a/iai-callgrind-macros/src/lib.rs
+++ b/iai-callgrind-macros/src/lib.rs
@@ -457,7 +457,6 @@ impl LibraryBenchmark {
                     self.parse_benches_attribute(item_fn, attr, &id)?;
                 }
                 Some(segment) => {
-                    // TODO: FIX ERROR MESSAGE
                     abort!(
                         attr, "Invalid attribute: '{}'", segment.ident;
                         help = "Only the `bench` and the `benches` attribute are allowed";

--- a/iai-callgrind-macros/src/lib.rs
+++ b/iai-callgrind-macros/src/lib.rs
@@ -659,6 +659,33 @@ impl MultipleArguments {
 /// # fn main() {}
 /// ```
 ///
+/// Assuming the same function `some_func`, the `benches` attribute lets you define multiple
+/// benchmarks in one go:
+/// ```rust
+/// # use iai_callgrind_macros::library_benchmark;
+/// # mod iai_callgrind {
+/// # pub struct LibraryBenchmarkConfig {}
+/// # pub mod internal {
+/// # pub struct InternalMacroLibBench {
+/// #   pub id_display: Option<&'static str>,
+/// #   pub args_display: Option<&'static str>,
+/// #   pub func: fn(),
+/// #   pub config: Option<fn() -> InternalLibraryBenchmarkConfig>
+/// # }
+/// # pub struct InternalLibraryBenchmarkConfig {}
+/// # }
+/// # }
+/// # fn some_func(value: u64) -> u64 {
+/// #    value
+/// # }
+/// #[library_benchmark]
+/// #[benches::some_id(21, 42, 84)]
+/// fn bench_some_func(value: u64) -> u64 {
+///     std::hint::black_box(some_func(value))
+/// }
+/// # fn main() {}
+/// ```
+///
 /// # Examples
 ///
 /// The `#[library_benchmark]` attribute as a standalone
@@ -726,9 +753,9 @@ impl MultipleArguments {
 ///     }
 /// }
 ///
-/// // This benchmark is setting up multiple benchmark cases with the advantage that the setup costs
-/// // for creating a vector (even if it is empty) aren't attributed to the benchmark and that the
-/// // `array` is already wrapped in a black_box.
+/// // This benchmark is setting up multiple benchmark cases with the advantage that the setup
+/// // costs  for creating a vector (even if it is empty) aren't attributed to the benchmark and
+/// // that the `array` is already wrapped in a black_box.
 /// #[library_benchmark]
 /// #[bench::empty(vec![])]
 /// #[bench::worst_case_6(vec![6, 5, 4, 3, 2, 1])]
@@ -739,6 +766,17 @@ impl MultipleArguments {
 /// fn bench_some_func_with_array(array: Vec<i32>) -> Vec<i32> {
 ///     // Note `array` does not need to be put in a `black_box` because that's already done for
 ///     // you.
+///     std::hint::black_box(some_func_with_array(array))
+/// }
+///
+/// // The following benchmark uses the `#[benches]` attribute to setup multiple benchmark cases
+/// // in one go
+/// #[library_benchmark]
+/// #[benches::multiple(vec![1], vec![5])]
+/// // Reroute the `args` to a `setup` function and use the setup function's return value as
+/// // input for the benchmarking function
+/// #[benches::with_setup(args = [1, 5], setup = setup_worst_case_array)]
+/// fn bench_using_the_benches_attribute(array: Vec<i32>) -> Vec<i32> {
 ///     std::hint::black_box(some_func_with_array(array))
 /// }
 /// # fn main() {

--- a/iai-callgrind/src/lib.rs
+++ b/iai-callgrind/src/lib.rs
@@ -63,7 +63,9 @@
 //! #### Quickstart (#library-benchmarks)
 //!
 //! ```rust
-//! use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+//! use iai_callgrind::{
+//!     library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig
+//! };
 //! use std::hint::black_box;
 //!
 //! // Our function we want to test. Just assume this is a public function in your
@@ -114,10 +116,41 @@
 //!     black_box(bubble_sort(array))
 //! }
 //!
+//! // You can use the `benches` attribute to specify multiple benchmark runs in one go. You can
+//! // specify multiple `benches` attributes or mix the `benches` attribute with `bench`
+//! // attributes.
+//! #[library_benchmark]
+//! // This is the simple form. Each `,`-separated element is another benchmark run and is
+//! // passed to the benchmarking function as parameter. So, this is the same as specifying
+//! // two `#[bench]` attributes #[bench::multiple_0(vec![1])] and #[bench::multiple_1(vec![5])].
+//! #[benches::multiple(vec![1], vec![5])]
+//! // You can also use the `args` argument to achieve the same. Using `args` is necessary if you
+//! // also want to specify a `config` or `setup` function.
+//! #[benches::with_args(args = [vec![1], vec![5]], config = LibraryBenchmarkConfig::default())]
+//! // Usually, each element in `args` is passed directly to the benchmarking function. You can
+//! // instead reroute them to a `setup` function. In that case the (black boxed) return value of
+//! // the setup function is passed as parameter to the benchmarking function.
+//! #[benches::with_setup(args = [1, 5], setup = setup_worst_case_array)]
+//! fn bench_bubble_sort_with_benches_attribute(input: Vec<i32>) -> Vec<i32> {
+//!     black_box(bubble_sort(input))
+//! }
+//!
+//! // A benchmarking function with multiple parameters requires the elements to be specified as
+//! // tuples.
+//! #[library_benchmark]
+//! #[benches::multiple((1, 2), (3, 4))]
+//! fn bench_bubble_sort_with_multiple_parameters(a: i32, b: i32) -> Vec<i32> {
+//!     black_box(bubble_sort(black_box(vec![a, b])))
+//! }
+//!
 //! // A group in which we can put all our benchmark functions
 //! library_benchmark_group!(
 //!     name = bubble_sort_group;
-//!     benchmarks = bench_bubble_sort_empty, bench_bubble_sort
+//!     benchmarks =
+//!         bench_bubble_sort_empty,
+//!         bench_bubble_sort,
+//!         bench_bubble_sort_with_benches_attribute,
+//!         bench_bubble_sort_with_multiple_parameters
 //! );
 //!
 //! # fn main() {

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_attributes.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_attributes.stderr
@@ -1,8 +1,8 @@
 error: Invalid attribute: 'b'
 
-         = help: Only the 'bench' attribute is allowed
-         = note: #[bench::my_id()] or #[bench::my_id("with", "args")]
-                           or #[bench::my_id(args = (arg1, ...), config = ...)]
+         = help: Only the `bench` and the `benches` attribute are allowed
+         = note: #[bench::my_id("with", "args")]
+                           or #[benches::my_id(args = [("with", "args"), ...)])]
 
  --> tests/ui/test_library_benchmark_invalid_attributes.rs:4:1
   |
@@ -11,9 +11,9 @@ error: Invalid attribute: 'b'
 
 error: Invalid attribute: 'inline'
 
-         = help: Only the 'bench' attribute is allowed
-         = note: #[bench::my_id()] or #[bench::my_id("with", "args")]
-                           or #[bench::my_id(args = (arg1, ...), config = ...)]
+         = help: Only the `bench` and the `benches` attribute are allowed
+         = note: #[bench::my_id("with", "args")]
+                           or #[benches::my_id(args = [("with", "args"), ...)])]
 
  --> tests/ui/test_library_benchmark_invalid_attributes.rs:8:1
   |
@@ -22,9 +22,9 @@ error: Invalid attribute: 'inline'
 
 error: Invalid attribute: 'inline'
 
-         = help: Only the 'bench' attribute is allowed
-         = note: #[bench::my_id()] or #[bench::my_id("with", "args")]
-                           or #[bench::my_id(args = (arg1, ...), config = ...)]
+         = help: Only the `bench` and the `benches` attribute are allowed
+         = note: #[bench::my_id("with", "args")]
+                           or #[benches::my_id(args = [("with", "args"), ...)])]
 
   --> tests/ui/test_library_benchmark_invalid_attributes.rs:11:1
    |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_attributes.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_attributes.stderr
@@ -1,7 +1,8 @@
 error: Invalid attribute: 'b'
 
          = help: Only the 'bench' attribute is allowed
-         = note: #[bench::my_id()] or #[bench::my_id("with", "args")] or #[bench::my_id(args = (arg1, ...), config = ...)]
+         = note: #[bench::my_id()] or #[bench::my_id("with", "args")]
+                           or #[bench::my_id(args = (arg1, ...), config = ...)]
 
  --> tests/ui/test_library_benchmark_invalid_attributes.rs:4:1
   |
@@ -11,7 +12,8 @@ error: Invalid attribute: 'b'
 error: Invalid attribute: 'inline'
 
          = help: Only the 'bench' attribute is allowed
-         = note: #[bench::my_id()] or #[bench::my_id("with", "args")] or #[bench::my_id(args = (arg1, ...), config = ...)]
+         = note: #[bench::my_id()] or #[bench::my_id("with", "args")]
+                           or #[bench::my_id(args = (arg1, ...), config = ...)]
 
  --> tests/ui/test_library_benchmark_invalid_attributes.rs:8:1
   |
@@ -21,7 +23,8 @@ error: Invalid attribute: 'inline'
 error: Invalid attribute: 'inline'
 
          = help: Only the 'bench' attribute is allowed
-         = note: #[bench::my_id()] or #[bench::my_id("with", "args")] or #[bench::my_id(args = (arg1, ...), config = ...)]
+         = note: #[bench::my_id()] or #[bench::my_id("with", "args")]
+                           or #[bench::my_id(args = (arg1, ...), config = ...)]
 
   --> tests/ui/test_library_benchmark_invalid_attributes.rs:11:1
    |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.rs
@@ -3,22 +3,35 @@ use iai_callgrind::library_benchmark;
 // missing argument of the benchmark
 #[library_benchmark]
 #[bench::id(42)]
-fn bench1() {}
+#[benches::multi(42)]
+fn bench10() {}
 
 // missing argument of the bench attribute
 #[library_benchmark]
 #[bench::id()]
-fn bench2(my: i32) {}
+fn bench20(my: i32) {}
+
+#[library_benchmark]
+#[benches::multi(args = [])]
+fn bench25(my: i32) {}
 
 // too many arguments of the bench attribute
 #[library_benchmark]
 #[bench::id(42, 8)]
-fn bench3(my: i32) {}
+fn bench30(my: i32) {}
+
+#[library_benchmark]
+#[benches::multi((42, 8))]
+fn bench30(my: i32) {}
 
 // incorrect argument type
 #[library_benchmark]
 #[bench::id("hello")]
-fn bench4(my: u8) {}
+fn bench40(my: u8) {}
+
+#[library_benchmark]
+#[benches::multi("hello")]
+fn bench45(my: u8) {}
 
 // incorrect return type
 #[library_benchmark]

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
@@ -1,12 +1,13 @@
 error: Expected 0 arguments but found 1
- --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:5:1
+ --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:5:3
   |
 5 | #[bench::id(42)]
-  | ^^^^^^^^^^^^^^^^
+  |   ^^^^^^^^^^^^^
 
 error: Expected 1 arguments but found none
 
-         = help: Try passing arguments either with #[bench::some_id(arg1, ...)] or with #[bench::some_id(args = (arg1, ...))]
+         = help: Try passing arguments either with #[bench::some_id(arg1, ...)]
+                       or with #[bench::some_id(args = (arg1, ...))]
 
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:10:1
    |
@@ -14,10 +15,10 @@ error: Expected 1 arguments but found none
    | ^^^^^^^^^^^^^^
 
 error: Expected 1 arguments but found 2
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:15:1
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:15:3
    |
 15 | #[bench::id(42, 8)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^
 
 error[E0603]: function `bench5` is private
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:39:13

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
@@ -4,64 +4,100 @@ error: Expected 0 arguments but found 1
 5 | #[bench::id(42)]
   |   ^^^^^^^^^^^^^
 
+error: Failed parsing arguments: Expected 0 values per tuple
+
+         = help: If the benchmarking function has multiple parameters
+                           the arguments for #[benches::...] must be given as tuple
+         = note: #[benches::id((1, 2), (3, 4))] or #[benches::id(args = [(1, 2), (3, 4)])]
+
+ --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:6:18
+  |
+6 | #[benches::multi(42)]
+  |                  ^^
+
 error: Expected 1 arguments but found none
 
          = help: Try passing arguments either with #[bench::some_id(arg1, ...)]
                        or with #[bench::some_id(args = (arg1, ...))]
 
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:10:1
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:11:1
    |
-10 | #[bench::id()]
+11 | #[bench::id()]
    | ^^^^^^^^^^^^^^
 
 error: Expected 1 arguments but found 2
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:15:3
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:20:3
    |
-15 | #[bench::id(42, 8)]
+20 | #[bench::id(42, 8)]
    |   ^^^^^^^^^^^^^^^^
 
-error[E0603]: function `bench5` is private
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:39:13
+error: Expected 1 arguments but found 2
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:24:3
    |
-39 |     bench5::bench5();
+24 | #[benches::multi((42, 8))]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0603]: function `bench5` is private
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:52:13
+   |
+52 |     bench5::bench5();
    |             ^^^^^^ private function
    |
 note: the function `bench5` is defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:26:1
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:39:1
    |
-26 | fn bench5(my: u8) -> String {
+39 | fn bench5(my: u8) -> String {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0603]: function `bench6` is private
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:41:13
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:54:13
    |
-41 |     bench6::bench6();
+54 |     bench6::bench6();
    |             ^^^^^^ private function
    |
 note: the function `bench6` is defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:31:5
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:44:5
    |
-31 | pub fn bench6() {}
+44 | pub fn bench6() {}
    |     ^^^^^^^^^^^
 
 error[E0603]: function `bench7` is private
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:43:13
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:56:13
    |
-43 |     bench7::bench7();
+56 |     bench7::bench7();
    |             ^^^^^^ private function
    |
 note: the function `bench7` is defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:35:5
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:48:5
    |
-35 | pub fn bench7() {}
+48 | pub fn bench7() {}
    |     ^^^^^^^^^^^
 
-error[E0308]: mismatched types
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:20:13
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:16:4
    |
-19 | #[library_benchmark]
+14 | #[library_benchmark]
+   | -------------------- an argument of type `i32` is missing
+15 | #[benches::multi(args = [])]
+16 | fn bench25(my: i32) {}
+   |    ^^^^^^^
+   |
+note: function defined here
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:16:4
+   |
+16 | fn bench25(my: i32) {}
+   |    ^^^^^^^ -------
+help: provide the argument
+   |
+14 | bench25(/* i32 */)
+   |
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:29:13
+   |
+28 | #[library_benchmark]
    | -------------------- arguments to this function are incorrect
-20 | #[bench::id("hello")]
+29 | #[bench::id("hello")]
    |             ^^^^^^^ expected `u8`, found `&str`
    |
 note: function defined here
@@ -71,27 +107,41 @@ note: function defined here
    |              ^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:27:5
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:33:18
    |
-26 | fn bench5(my: u8) -> String {
+32 | #[library_benchmark]
+   | -------------------- arguments to this function are incorrect
+33 | #[benches::multi("hello")]
+   |                  ^^^^^^^ expected `u8`, found `&str`
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:40:5
+   |
+39 | fn bench5(my: u8) -> String {
    |                      ------ expected `String` because of return type
-27 |     my
+40 |     my
    |     ^^- help: try using a conversion method: `.to_string()`
    |     |
    |     expected struct `String`, found `u8`
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:39:5
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:52:5
    |
-39 |     bench5::bench5();
+52 |     bench5::bench5();
    |     ^^^^^^^^^^^^^^-- an argument of type `u8` is missing
    |
 note: function defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:26:4
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:39:4
    |
-26 | fn bench5(my: u8) -> String {
+39 | fn bench5(my: u8) -> String {
    |    ^^^^^^ ------
 help: provide the argument
    |
-39 |     bench5::bench5(/* u8 */);
+52 |     bench5::bench5(/* u8 */);
    |                   ~~~~~~~~~~

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
@@ -7,7 +7,13 @@ error: Invalid argument: invalid
 4 | #[bench::id(invalid = "value")]
   |             ^^^^^^^^^^^^^^^^^
 
-error: expected tuple expression
+error: Failed parsing `args`
+
+         = help: `args` must be an tuple/array which elements (expressions)
+                                   match the number of parameters of the benchmarking function
+         = note: #[bench::id(args = (1, 2))] or
+                                   #[bench::id(args = [1, 2]])]
+
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.rs:8:20
   |
 8 | #[bench::id(args = "value")]

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs
@@ -2,14 +2,26 @@ use iai_callgrind::library_benchmark;
 
 #[library_benchmark]
 #[bench::id(config = "some")]
-pub fn bench0() {}
+pub fn bench00() {}
 
 #[library_benchmark]
 #[bench::id(wrong = LibraryBenchmarkConfig::default())]
-pub fn bench1() {}
+pub fn bench10() {}
 
 #[library_benchmark]
 #[bench::id(config = )]
-pub fn bench2() {}
+pub fn bench20() {}
+
+#[library_benchmark]
+#[benches::wrong(wrong = LibraryBenchmarkConfig::default())]
+pub fn bench30() {}
+
+#[library_benchmark]
+#[benches::missing_args(config = LibraryBenchmarkConfig::default())]
+pub fn bench40(_arg: i32) {}
+
+#[library_benchmark]
+#[benches::missing_expression(args = [], config = )]
+pub fn bench50() {}
 
 fn main() {}

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
@@ -13,6 +13,33 @@ error: unexpected end of input, expected an expression
 12 | #[bench::id(config = )]
    |                      ^
 
+error: Invalid argument: wrong
+
+         = help: Valid arguments are: `args`, `config`, `setup`
+
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:16:18
+   |
+16 | #[benches::wrong(wrong = LibraryBenchmarkConfig::default())]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Missing arguments for `benches`
+
+         = help: Either specify the `args` argument or use plain arguments
+         = note: `#[benches::id(args = [...])]` or `#[benches::id(1, 2, ...)]`
+
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:20:3
+   |
+20 | #[benches::missing_args(config = LibraryBenchmarkConfig::default())]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unexpected end of input, expected an expression
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:23:1
+   |
+23 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `InternalLibraryBenchmarkConfig: From<&str>` is not satisfied
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:4:22
   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_id.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_id.rs
@@ -14,4 +14,13 @@ fn bench2() {}
 #[bench::same()]
 fn bench3() {}
 
+#[library_benchmark]
+#[benches::no_args()]
+fn bench4() {}
+
+#[library_benchmark]
+#[benches::same(1)]
+#[benches::same(1)]
+fn bench5(_arg: i32) {}
+
 fn main() {}

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_id.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_id.stderr
@@ -25,3 +25,15 @@ error[E0428]: the name `same` is defined multiple times
    |
    = note: `same` must be defined only once in the value namespace of this module
    = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0428]: the name `same_0` is defined multiple times
+  --> tests/ui/test_library_benchmark_invalid_bench_id.rs:21:1
+   |
+21 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `same_0` redefined here
+   | previous definition of the value `same_0` here
+   |
+   = note: `same_0` must be defined only once in the value namespace of this module
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_id.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_id.stderr
@@ -1,7 +1,7 @@
 error: An id is required
 
          = help: bench followed by :: and an unique id
-         = note: bench::my_id
+         = note: #[bench::my_id(...)]
 
  --> tests/ui/test_library_benchmark_invalid_bench_id.rs:5:1
   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_valid_benches_arguments.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_valid_benches_arguments.rs
@@ -1,0 +1,68 @@
+use iai_callgrind::library_benchmark;
+
+fn some_setup(my: u8) -> u64 {
+    my as u64 + 1
+}
+
+fn some_two_setup(a: i32, b: i32) -> (i32, i32) {
+    (a + b, a - b)
+}
+
+fn some_two_to_one_setup(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[library_benchmark]
+#[benches::id10(8)]
+#[benches::id15(8 + 9)]
+#[benches::id20((8))]
+#[benches::id30(8, 9)]
+#[benches::id35(8, 9 + 10)]
+#[benches::id40((8), (9))]
+#[benches::id50(args = [8])]
+#[benches::id60(args = [8, 9])]
+fn bench110(arg: u8) -> u8 {
+    arg
+}
+
+#[library_benchmark]
+#[benches::id10(((8, 9)))]
+#[benches::id15(((8, 9)), ((10, 20)))]
+#[benches::id20(args = [((8, 9))])]
+#[benches::id30(args = [((8, 9)), ((10, 20))])]
+fn bench115((arg1, arg2): (u8, u8)) -> u8 {
+    arg1 + arg2
+}
+
+#[library_benchmark]
+#[benches::id10((1, 2))]
+#[benches::id20((1, 2), (3, 4))]
+#[benches::id30(args = [(1, 2)])]
+#[benches::id40(args = [(1, 2), (3, 4)])]
+fn bench120(first: u8, second: u8) -> u8 {
+    first + second
+}
+
+#[library_benchmark]
+#[benches::id10(args = [1, 2], setup = some_setup)]
+#[benches::id20(args = [1 + 2, 2], setup = some_setup)]
+#[benches::id30(args = [(1 + 2), 2], setup = some_setup)]
+fn bench125(arg1: u64) -> u64 {
+    arg1
+}
+
+#[library_benchmark]
+#[benches::id10(args = [(1, 2)], setup = some_two_setup)]
+#[benches::id20(args = [(1, 2), (3, 4)], setup = some_two_setup)]
+fn bench130((a, b): (i32, i32)) -> i32 {
+    a + b
+}
+
+#[library_benchmark]
+#[benches::id10(args = [(1, 2)], setup = some_two_to_one_setup)]
+#[benches::id20(args = [(1, 2), (3, 4)], setup = some_two_to_one_setup)]
+fn bench140(a: i32) -> i32 {
+    a
+}
+
+fn main() {}


### PR DESCRIPTION
This pr adds the possibility to specify multiple benchmarks in one go in a single `benches` attribute

From the documentation:

```rust
// You can use the `benches` attribute to specify multiple benchmark runs in one go. You can specify
// multiple `benches` attributes or mix the `benches` attribute with `bench` attributes.
#[library_benchmark]
// This is the simple form. Each `,`-separated element is another benchmark run and is passed to the
// benchmarking function as parameter. So, this is the same as specifying two `#[bench]` attributes
// #[bench::multiple_0(vec![1])] and #[bench::multiple_1(vec![5])].
#[benches::multiple(vec![1], vec![5])]
// You can also use the `args` argument to achieve the same. Using `args` is necessary if you also
// want to specify a `config` or `setup` function.
#[benches::with_args(args = [vec![1], vec![5]], config = LibraryBenchmarkConfig::default())]
// Usually, each element in `args` is passed directly to the benchmarking function. You can instead
// reroute them to a `setup` function. In that case the (black boxed) return value of the setup
// function is passed as parameter to the benchmarking function.
#[benches::with_setup(args = [1, 5], setup = setup_worst_case_array)]
fn bench_bubble_sort_with_benches_attribute(input: Vec<i32>) -> Vec<i32> {
    black_box(bubble_sort(input))
}

// The same as above in `bench_bubble_sort_with_benches_attribute` but a function with multiple
// parameters requires the elements to be specified as tuples.
#[library_benchmark]
#[benches::multiple((1, 2), (3, 4))]
#[benches::with_args(args = [(1, 2), (3, 4)])]
fn bench_bubble_sort_with_multiple_parameters(a: i32, b: i32) -> Vec<i32> {
    black_box(bubble_sort(black_box(vec![a, b])))
}
```

@jalil-salame I've taken a part from your example use case in #38 and adjusted it to the current possible usage:

```rust
#[library_benchmark]
#[benches::worst_case(args = [2, 4, 8, 16, 32, 64, 128, 256], setup = linear_worst_case)]
#[benches::good_case(args = [2, 4, 8, 16, 32, 64, 128, 256], setup = binary_good_case)]
#[benches::best_case(args = [2, 4, 8, 16, 32, 64, 128, 256], setup = binary_best_case)]
fn bench_linear((nums, target): (Vec<i32>, i32)) {
    black_box(linear(black_box(nums), black_box(target)));
}
```

Is this what you wanted?

Closes #38