### PR TITLE
Replace proc-macro-error with proc-macro2-diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,8 +726,8 @@ name = "iai-callgrind-macros"
 version = "0.2.0"
 dependencies = [
  "pretty_assertions",
- "proc-macro-error",
  "proc-macro2",
+ "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.46",
 ]
@@ -1141,36 +1141,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ log = { version = "0.4" }
 new_string_template = { version = "1.4" }
 predicates = { version = "3" }
 pretty_assertions = "1.1"
-proc-macro-error = "1"
 proc-macro2 = "1.0.60"
+proc-macro2-diagnostics = { version = "0.10.1", default-features = false }
 quote = "1"
 regex = { version = "1" }
 rstest = ">=0.17, <0.19"

--- a/iai-callgrind-macros/Cargo.toml
+++ b/iai-callgrind-macros/Cargo.toml
@@ -16,8 +16,8 @@ version = "0.2.0"
 proc-macro = true
 
 [dependencies]
-proc-macro-error = { workspace = true }
 proc-macro2 = { workspace = true }
+proc-macro2-diagnostics = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
 


### PR DESCRIPTION
proc-macro-error is not maintained any more and depends on an old version of syn (Other packages too, therefore it's not removed yet).

I still need to test this (and probably clean it up a bti).