### PR TITLE
Fix: positional arguments from `cargo bench` cause iai-callgrind to exit with error

### DIFF
--- a/iai-callgrind-runner/src/runner/args.rs
+++ b/iai-callgrind-runner/src/runner/args.rs
@@ -25,6 +25,10 @@ pub struct CommandLineArgs {
     #[arg(long = "bench", hide = true, action = ArgAction::SetTrue, required = false)]
     pub _bench: bool,
 
+    /// We ignore any positional arguments
+    #[arg(hide = true)]
+    pub _filter: Option<String>,
+
     /// The raw arguments to pass through to Callgrind
     ///
     /// This is a space separated list of command-line-arguments specified as if they were


### PR DESCRIPTION
`cargo bench` allows to specify a filter for benchmark names as positional argument. This positional argument is passed through to the `iai-callgrind-runner` which isn't able to handle positional arguments and exits with error.

This pr fixes it by ignoring any positional arguments.