### PR TITLE
feat: Add support to filter benchmarks by name

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -1,6 +1,7 @@
 ASLR
 Aparicio
 Assche
+BENCHNAME
 Benchmarkable
 Boolish
 CALLGRIND

--- a/Justfile
+++ b/Justfile
@@ -165,7 +165,7 @@ bench-test bench: build-runner
 
 # Run all benchmark tests
 bench-test-all: build-runner
-    IAI_CALLGRIND_RUNNER=$(readlink -e target/release/iai-callgrind-runner) cargo bench -p benchmark-tests
+    IAI_CALLGRIND_RUNNER=$(readlink -e target/release/iai-callgrind-runner) cargo bench -p benchmark-tests {{ if args != '' { '-- ' + args } else { '' } }}
 
 # Note: A single benchmark may run multiple times depending on the test
 #       configuration. See the `benchmark-tests/benches` folder.

--- a/benchmark-tests/benches/test_bench.rs
+++ b/benchmark-tests/benches/test_bench.rs
@@ -14,7 +14,9 @@ fn setup_worst_case_array(start: i32) -> Vec<i32> {
 #[library_benchmark]
 #[bench::worst_case(setup_worst_case_array(20))]
 fn bench_bubble_sort(array: Vec<i32>) -> Vec<i32> {
-    black_box(bubble_sort(array))
+    let result = black_box(bubble_sort(array));
+    println!("{:?}", result);
+    result
 }
 
 library_benchmark_group!(

--- a/benchmark-tests/benches/test_lib_bench_single.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench_single.conf.yml
@@ -6,7 +6,7 @@ groups:
           files: test_lib_bench_single.expected.1.yml
           stdout: test_lib_bench_single.stdout.1
         template_data:
-          worst_case_start: 10
+          worst_case_start: 0
       - args: ["--save-baseline=bar"]
         expected:
           files: test_lib_bench_single.expected.2.yml

--- a/benchmark-tests/benches/test_lib_bench_single.rs.j2
+++ b/benchmark-tests/benches/test_lib_bench_single.rs.j2
@@ -14,7 +14,9 @@ fn setup_worst_case_array(start: i32) -> Vec<i32> {
 #[library_benchmark]
 #[bench::worst_case(setup_worst_case_array({{ worst_case_start }}))]
 fn bench_bubble_sort(array: Vec<i32>) -> Vec<i32> {
-    black_box(bubble_sort(array))
+    let result = black_box(bubble_sort(array));
+    println!("{:?}", result);
+    result
 }
 
 library_benchmark_group!(

--- a/benchmark-tests/benches/test_lib_bench_single.stdout.1
+++ b/benchmark-tests/benches/test_lib_bench_single.stdout.1
@@ -1,4 +1,4 @@
-test_bench::bench_group::bench_bubble_sort worst_case:setup_worst_case_array(10)
+test_bench::bench_group::bench_bubble_sort worst_case:setup_worst_case_array(0)
   Baselines:                    foo|foo
   Instructions:                    |N/A             (*********)
   L1 Hits:                         |N/A             (*********)

--- a/benchmark-tests/benches/test_lib_bench_single.stdout.3
+++ b/benchmark-tests/benches/test_lib_bench_single.stdout.3
@@ -2,7 +2,7 @@ test_bench::bench_group::bench_bubble_sort worst_case:setup_worst_case_array(20)
   Baselines:                    bar|foo
   Instructions:                    |                (+       %) [+       x]
   L1 Hits:                         |                (+       %) [+       x]
-  L2 Hits:                         |                (No change)
-  RAM Hits:                        |                (No change)
+  L2 Hits:                         |                (+       %) [+       x]
+  RAM Hits:                        |                (+       %) [+       x]
   Total read+write:                |                (+       %) [+       x]
   Estimated Cycles:                |                (+       %) [+       x]

--- a/iai-callgrind/src/macros.rs
+++ b/iai-callgrind/src/macros.rs
@@ -180,6 +180,7 @@ macro_rules! main {
             cmd.arg(library_version);
             cmd.arg("--bin-bench");
             cmd.arg(env!("CARGO_MANIFEST_DIR"));
+            cmd.arg(env!("CARGO_PKG_NAME"));
             cmd.arg(file!());
             cmd.arg(module_path!());
             cmd.arg(this_args.next().unwrap()); // The executable benchmark binary
@@ -280,6 +281,7 @@ macro_rules! main {
             cmd.arg(library_version);
             cmd.arg("--lib-bench");
             cmd.arg(env!("CARGO_MANIFEST_DIR"));
+            cmd.arg(env!("CARGO_PKG_NAME"));
             cmd.arg(file!());
             cmd.arg(module_path!());
             cmd.arg(this_args.next().unwrap()); // The executable benchmark binary


### PR DESCRIPTION
This pr is a follow up to #86 and adds support to filter benchmarks by BENCHNAME

```
cargo bench BENCHNAME
```

Also, the usage in `--help` is fixed to show `Usage: cargo bench ...` instead of the misleading `Usage: iai-callgrind-runner ...`.