### PR TITLE
Support for optimized asm instructions on aarch64 freebsd

### DIFF
--- a/iai-callgrind/build.rs
+++ b/iai-callgrind/build.rs
@@ -124,7 +124,9 @@ mod imp {
             Some(Support::X86)
         } else if target.arch == "arm" && target.os == "linux" && target.env == "gnu" {
             Some(Support::Arm)
-        } else if target.arch == "aarch64" && target.os == "linux" && target.env == "gnu" {
+        } else if target.arch == "aarch64"
+            && (target.os == "freebsd" || (target.os == "linux" && target.env == "gnu"))
+        {
             Some(Support::Aarch64)
         } else {
             let re = regex::Regex::new(


### PR DESCRIPTION
Since valgrind 3.23.0 supports client requests for aarch64/freebsd. This pr adds this target to the supported targets for the optimized rust inline assembly.