### PR TITLE
Fix iai-callgrind-runner binary benchmarks were not able to copy fixtures on FreeBSD

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -1,3 +1,5 @@
+binstall
+nocapture
 ASLR
 Aparicio
 Assche

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,5 +1,6 @@
 # spell-checker:ignore taiki rustfmt binstall clippy taplo rustup nocapture
-# spell-checker:ignore nofile gnuabi armv gnueabi mipsel
+# spell-checker:ignore nofile gnuabi armv gnueabi mipsel vmactions usesh proto
+# spell-checker:ignore tlsv connrefused
 
 name: Build and Check
 
@@ -20,143 +21,143 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deny:
-    name: Check dependencies/ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.66.0
-      - uses: taiki-e/install-action@cargo-deny
-      - uses: taiki-e/install-action@just
-      - name: Check advisories
-        run: just args='--deny warnings' deny advisories
-      - name: Check bans licenses sources
-        run: just deny bans licenses sources
-
-  minimal_versions:
-    name: Check minimal version requirements of dependencies
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain:
-          - "1.66.0" # MSRV
-          - stable
-          # https://github.com/tkaitchuck/aHash/issues/200
-          # Pin nightly as long as inferno can use ahash < 0.8.7
-          - nightly-2024-02-04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        if: ${{ startsWith(matrix.toolchain, 'nightly') }}
-        with:
-          toolchain: ${{ matrix.toolchain }}
-      - uses: dtolnay/rust-toolchain@master
-        if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
-        with:
-          toolchain: nightly
-      - uses: dtolnay/rust-toolchain@master
-        if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
-        with:
-          toolchain: ${{ matrix.toolchain }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ubuntu-latest_${{ matrix.toolchain }}
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: taiki-e/install-action@cargo-minimal-versions
-      - uses: taiki-e/install-action@just
-      - name: Check build with minimal versions
-        run: just minimal-versions
-
-  format:
-    name: Check format and spelling
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-      - uses: taiki-e/install-action@cargo-binstall
-      - uses: taiki-e/install-action@just
-      - run: cargo binstall --no-confirm --no-symlinks taplo-cli
-      - run: just check-fmt-all
-
-  base:
-    needs: [format]
-    name: Build, check and test
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain:
-          - "1.66.0" # MSRV
-          - stable
-          - nightly
-        include:
-          - toolchain: "1.66.0" # MSRV
-            ui_tests: --features ui_tests
-            components: rust-src
-          - toolchain: stable
-            components: clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          components: ${{ matrix.components }}
-      - name: "Prepare: Install stable toolchain with clippy"
-        if: matrix.toolchain != 'stable'
-        run: |
-          rustup toolchain install stable --no-self-update --component clippy
-      - name: "Prepare: Run cargo update"
-        if: matrix.toolchain == 'stable' || matrix.toolchain == 'nightly'
-        run: |
-          cargo update
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: taiki-e/install-action@just
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ubuntu-latest_${{ matrix.toolchain }}
-      - name: Install valgrind
-        run: sudo apt-get -y update && sudo apt-get -y install valgrind
-      - name: Info
-        run: |
-          set -x
-          uname -a
-          pwd
-          rustup --version
-          rustup show
-          rustup component list --installed
-          valgrind --version
-      - name: Build with the feature powerset
-        run: just build-hack
-      - name: Lint
-        run: just lint
-      - name: Test
-        run: |
-          set -o pipefail
-          cargo test --workspace --exclude client-request-tests ${{ matrix.ui_tests }} |& tee test.output
-      - name: Check test output for ui errors
-        if: ${{ matrix.ui_tests && failure() }}
-        run: |
-          if grep -q '^test ui \.\.\. FAILED$' test.output; then
-            TRYBUILD=overwrite cargo test ${{ matrix.ui_tests }} ui
-            git diff iai-callgrind/tests/ui
-          fi
-          exit 1
-      - name: Check summary.json schema is up-to-date
-        run: just schema-gen-diff
-      - name: Bench
-        run: just full-bench-test-all
-        # env:
-        # IAI_CALLGRIND_LOG: trace
-      - uses: actions/upload-artifact@v4
-        with:
-          name: iai-callgrind-benchmarks-${{ matrix.toolchain }}
-          path: "target/iai"
+  # deny:
+  #   name: Check dependencies/ubuntu-latest
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@1.66.0
+  #     - uses: taiki-e/install-action@cargo-deny
+  #     - uses: taiki-e/install-action@just
+  #     - name: Check advisories
+  #       run: just args='--deny warnings' deny advisories
+  #     - name: Check bans licenses sources
+  #       run: just deny bans licenses sources
+  #
+  # minimal_versions:
+  #   name: Check minimal version requirements of dependencies
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       toolchain:
+  #         - "1.66.0" # MSRV
+  #         - stable
+  #         # https://github.com/tkaitchuck/aHash/issues/200
+  #         # Pin nightly as long as inferno can use ahash < 0.8.7
+  #         - nightly-2024-02-04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@master
+  #       if: ${{ startsWith(matrix.toolchain, 'nightly') }}
+  #       with:
+  #         toolchain: ${{ matrix.toolchain }}
+  #     - uses: dtolnay/rust-toolchain@master
+  #       if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
+  #       with:
+  #         toolchain: nightly
+  #     - uses: dtolnay/rust-toolchain@master
+  #       if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
+  #       with:
+  #         toolchain: ${{ matrix.toolchain }}
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         key: ubuntu-latest_${{ matrix.toolchain }}
+  #     - uses: taiki-e/install-action@cargo-hack
+  #     - uses: taiki-e/install-action@cargo-minimal-versions
+  #     - uses: taiki-e/install-action@just
+  #     - name: Check build with minimal versions
+  #       run: just minimal-versions
+  #
+  # format:
+  #   name: Check format and spelling
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@nightly
+  #       with:
+  #         components: rustfmt
+  #     - uses: taiki-e/install-action@cargo-binstall
+  #     - uses: taiki-e/install-action@just
+  #     - run: cargo binstall --no-confirm --no-symlinks taplo-cli
+  #     - run: just check-fmt-all
+  #
+  # base:
+  #   needs: [format]
+  #   name: Build, check and test
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       toolchain:
+  #         - "1.66.0" # MSRV
+  #         - stable
+  #         - nightly
+  #       include:
+  #         - toolchain: "1.66.0" # MSRV
+  #           ui_tests: --features ui_tests
+  #           components: rust-src
+  #         - toolchain: stable
+  #           components: clippy
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@master
+  #       with:
+  #         toolchain: ${{ matrix.toolchain }}
+  #         components: ${{ matrix.components }}
+  #     - name: "Prepare: Install stable toolchain with clippy"
+  #       if: matrix.toolchain != 'stable'
+  #       run: |
+  #         rustup toolchain install stable --no-self-update --component clippy
+  #     - name: "Prepare: Run cargo update"
+  #       if: matrix.toolchain == 'stable' || matrix.toolchain == 'nightly'
+  #       run: |
+  #         cargo update
+  #     - uses: taiki-e/install-action@cargo-hack
+  #     - uses: taiki-e/install-action@just
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         key: ubuntu-latest_${{ matrix.toolchain }}
+  #     - name: Install valgrind
+  #       run: sudo apt-get -y update && sudo apt-get -y install valgrind
+  #     - name: Info
+  #       run: |
+  #         set -x
+  #         uname -a
+  #         pwd
+  #         rustup --version
+  #         rustup show
+  #         rustup component list --installed
+  #         valgrind --version
+  #     - name: Build with the feature powerset
+  #       run: just build-hack
+  #     - name: Lint
+  #       run: just lint
+  #     - name: Test
+  #       run: |
+  #         set -o pipefail
+  #         cargo test --workspace --exclude client-request-tests ${{ matrix.ui_tests }} |& tee test.output
+  #     - name: Check test output for ui errors
+  #       if: ${{ matrix.ui_tests && failure() }}
+  #       run: |
+  #         if grep -q '^test ui \.\.\. FAILED$' test.output; then
+  #           TRYBUILD=overwrite cargo test ${{ matrix.ui_tests }} ui
+  #           git diff iai-callgrind/tests/ui
+  #         fi
+  #         exit 1
+  #     - name: Check summary.json schema is up-to-date
+  #       run: just schema-gen-diff
+  #     - name: Bench
+  #       run: just full-bench-test-all
+  #       # env:
+  #       # IAI_CALLGRIND_LOG: trace
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: iai-callgrind-benchmarks-${{ matrix.toolchain }}
+  #         path: "target/iai"
 
   client_requests:
-    needs: [format]
+    # needs: [format]
     name: Test client requests
     strategy:
       fail-fast: false
@@ -200,19 +201,41 @@ jobs:
         # env:
         #   CROSS_DEBUG: "1"
 
-  docs:
-    needs: [base, client_requests]
-    name: Docs/ubuntu-latest
+  freebsd:
+    name: Build, check and test/FreeBSD
+    # needs: [format]
     runs-on: ubuntu-latest
     env:
-      DOCS_RS: "1"
+      IAI_CALLGRIND_VALGRIND_INCLUDE: "/usr/local/include"
+      IAI_CALLGRIND_VALGRIND_PATH: "/usr/local/bin"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-      - name: Build iai-callgrind without valgrind headers
-        run: cargo build --package iai-callgrind --features client_requests_defs --release
-      - name: Run doc tests
-        run: cargo test --all-features --doc
-      - name: Check Documentation
-        run: cargo doc --all-features --no-deps --document-private-items
+      - name: Setup and run tests
+        id: test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          envs: "IAI_CALLGRIND_VALGRIND_INCLUDE IAI_CALLGRIND_VALGRIND_PATH"
+          usesh: true
+          prepare: |
+            pkg install -y valgrind curl llvm18 just npm-node21
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain stable --profile minimal -y
+          run: |
+            ./scripts/freebsd_print_info.sh
+            ./scripts/freebsd_build_and_test.sh
+
+  # docs:
+  #   needs: [base, client_requests]
+  #   name: Docs/ubuntu-latest
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     DOCS_RS: "1"
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@nightly
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Build iai-callgrind without valgrind headers
+  #       run: cargo build --package iai-callgrind --features client_requests_defs --release
+  #     - name: Run doc tests
+  #       run: cargo test --all-features --doc
+  #     - name: Check Documentation
+  #       run: cargo doc --all-features --no-deps --document-private-items

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,143 +21,143 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # deny:
-  #   name: Check dependencies/ubuntu-latest
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@1.66.0
-  #     - uses: taiki-e/install-action@cargo-deny
-  #     - uses: taiki-e/install-action@just
-  #     - name: Check advisories
-  #       run: just args='--deny warnings' deny advisories
-  #     - name: Check bans licenses sources
-  #       run: just deny bans licenses sources
-  #
-  # minimal_versions:
-  #   name: Check minimal version requirements of dependencies
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       toolchain:
-  #         - "1.66.0" # MSRV
-  #         - stable
-  #         # https://github.com/tkaitchuck/aHash/issues/200
-  #         # Pin nightly as long as inferno can use ahash < 0.8.7
-  #         - nightly-2024-02-04
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@master
-  #       if: ${{ startsWith(matrix.toolchain, 'nightly') }}
-  #       with:
-  #         toolchain: ${{ matrix.toolchain }}
-  #     - uses: dtolnay/rust-toolchain@master
-  #       if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
-  #       with:
-  #         toolchain: nightly
-  #     - uses: dtolnay/rust-toolchain@master
-  #       if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
-  #       with:
-  #         toolchain: ${{ matrix.toolchain }}
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         key: ubuntu-latest_${{ matrix.toolchain }}
-  #     - uses: taiki-e/install-action@cargo-hack
-  #     - uses: taiki-e/install-action@cargo-minimal-versions
-  #     - uses: taiki-e/install-action@just
-  #     - name: Check build with minimal versions
-  #       run: just minimal-versions
-  #
-  # format:
-  #   name: Check format and spelling
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@nightly
-  #       with:
-  #         components: rustfmt
-  #     - uses: taiki-e/install-action@cargo-binstall
-  #     - uses: taiki-e/install-action@just
-  #     - run: cargo binstall --no-confirm --no-symlinks taplo-cli
-  #     - run: just check-fmt-all
-  #
-  # base:
-  #   needs: [format]
-  #   name: Build, check and test
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       toolchain:
-  #         - "1.66.0" # MSRV
-  #         - stable
-  #         - nightly
-  #       include:
-  #         - toolchain: "1.66.0" # MSRV
-  #           ui_tests: --features ui_tests
-  #           components: rust-src
-  #         - toolchain: stable
-  #           components: clippy
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@master
-  #       with:
-  #         toolchain: ${{ matrix.toolchain }}
-  #         components: ${{ matrix.components }}
-  #     - name: "Prepare: Install stable toolchain with clippy"
-  #       if: matrix.toolchain != 'stable'
-  #       run: |
-  #         rustup toolchain install stable --no-self-update --component clippy
-  #     - name: "Prepare: Run cargo update"
-  #       if: matrix.toolchain == 'stable' || matrix.toolchain == 'nightly'
-  #       run: |
-  #         cargo update
-  #     - uses: taiki-e/install-action@cargo-hack
-  #     - uses: taiki-e/install-action@just
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         key: ubuntu-latest_${{ matrix.toolchain }}
-  #     - name: Install valgrind
-  #       run: sudo apt-get -y update && sudo apt-get -y install valgrind
-  #     - name: Info
-  #       run: |
-  #         set -x
-  #         uname -a
-  #         pwd
-  #         rustup --version
-  #         rustup show
-  #         rustup component list --installed
-  #         valgrind --version
-  #     - name: Build with the feature powerset
-  #       run: just build-hack
-  #     - name: Lint
-  #       run: just lint
-  #     - name: Test
-  #       run: |
-  #         set -o pipefail
-  #         cargo test --workspace --exclude client-request-tests ${{ matrix.ui_tests }} |& tee test.output
-  #     - name: Check test output for ui errors
-  #       if: ${{ matrix.ui_tests && failure() }}
-  #       run: |
-  #         if grep -q '^test ui \.\.\. FAILED$' test.output; then
-  #           TRYBUILD=overwrite cargo test ${{ matrix.ui_tests }} ui
-  #           git diff iai-callgrind/tests/ui
-  #         fi
-  #         exit 1
-  #     - name: Check summary.json schema is up-to-date
-  #       run: just schema-gen-diff
-  #     - name: Bench
-  #       run: just full-bench-test-all
-  #       # env:
-  #       # IAI_CALLGRIND_LOG: trace
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: iai-callgrind-benchmarks-${{ matrix.toolchain }}
-  #         path: "target/iai"
+  deny:
+    name: Check dependencies/ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.66.0
+      - uses: taiki-e/install-action@cargo-deny
+      - uses: taiki-e/install-action@just
+      - name: Check advisories
+        run: just args='--deny warnings' deny advisories
+      - name: Check bans licenses sources
+        run: just deny bans licenses sources
+
+  minimal_versions:
+    name: Check minimal version requirements of dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - "1.66.0" # MSRV
+          - stable
+          # https://github.com/tkaitchuck/aHash/issues/200
+          # Pin nightly as long as inferno can use ahash < 0.8.7
+          - nightly-2024-02-04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        if: ${{ startsWith(matrix.toolchain, 'nightly') }}
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - uses: dtolnay/rust-toolchain@master
+        if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
+        with:
+          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@master
+        if: ${{ ! startsWith(matrix.toolchain, 'nightly') }}
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-latest_${{ matrix.toolchain }}
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - uses: taiki-e/install-action@just
+      - name: Check build with minimal versions
+        run: just minimal-versions
+
+  format:
+    name: Check format and spelling
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - uses: taiki-e/install-action@cargo-binstall
+      - uses: taiki-e/install-action@just
+      - run: cargo binstall --no-confirm --no-symlinks taplo-cli
+      - run: just check-fmt-all
+
+  base:
+    needs: [format]
+    name: Build, check and test
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - "1.66.0" # MSRV
+          - stable
+          - nightly
+        include:
+          - toolchain: "1.66.0" # MSRV
+            ui_tests: --features ui_tests
+            components: rust-src
+          - toolchain: stable
+            components: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: ${{ matrix.components }}
+      - name: "Prepare: Install stable toolchain with clippy"
+        if: matrix.toolchain != 'stable'
+        run: |
+          rustup toolchain install stable --no-self-update --component clippy
+      - name: "Prepare: Run cargo update"
+        if: matrix.toolchain == 'stable' || matrix.toolchain == 'nightly'
+        run: |
+          cargo update
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@just
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-latest_${{ matrix.toolchain }}
+      - name: Install valgrind
+        run: sudo apt-get -y update && sudo apt-get -y install valgrind
+      - name: Info
+        run: |
+          set -x
+          uname -a
+          pwd
+          rustup --version
+          rustup show
+          rustup component list --installed
+          valgrind --version
+      - name: Build with the feature powerset
+        run: just build-hack
+      - name: Lint
+        run: just lint
+      - name: Test
+        run: |
+          set -o pipefail
+          cargo test --workspace --exclude client-request-tests ${{ matrix.ui_tests }} |& tee test.output
+      - name: Check test output for ui errors
+        if: ${{ matrix.ui_tests && failure() }}
+        run: |
+          if grep -q '^test ui \.\.\. FAILED$' test.output; then
+            TRYBUILD=overwrite cargo test ${{ matrix.ui_tests }} ui
+            git diff iai-callgrind/tests/ui
+          fi
+          exit 1
+      - name: Check summary.json schema is up-to-date
+        run: just schema-gen-diff
+      - name: Bench
+        run: just full-bench-test-all
+        # env:
+        # IAI_CALLGRIND_LOG: trace
+      - uses: actions/upload-artifact@v4
+        with:
+          name: iai-callgrind-benchmarks-${{ matrix.toolchain }}
+          path: "target/iai"
 
   client_requests:
-    # needs: [format]
+    needs: [format]
     name: Test client requests
     strategy:
       fail-fast: false
@@ -203,7 +203,7 @@ jobs:
 
   freebsd:
     name: Build, check and test/FreeBSD
-    # needs: [format]
+    needs: [format]
     runs-on: ubuntu-latest
     env:
       IAI_CALLGRIND_VALGRIND_INCLUDE: "/usr/local/include"
@@ -223,19 +223,19 @@ jobs:
             ./scripts/freebsd_print_info.sh
             ./scripts/freebsd_build_and_test.sh
 
-  # docs:
-  #   needs: [base, client_requests]
-  #   name: Docs/ubuntu-latest
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     DOCS_RS: "1"
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@nightly
-  #     - uses: Swatinem/rust-cache@v2
-  #     - name: Build iai-callgrind without valgrind headers
-  #       run: cargo build --package iai-callgrind --features client_requests_defs --release
-  #     - name: Run doc tests
-  #       run: cargo test --all-features --doc
-  #     - name: Check Documentation
-  #       run: cargo doc --all-features --no-deps --document-private-items
+  docs:
+    needs: [base, client_requests]
+    name: Docs/ubuntu-latest
+    runs-on: ubuntu-latest
+    env:
+      DOCS_RS: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - name: Build iai-callgrind without valgrind headers
+        run: cargo build --package iai-callgrind --features client_requests_defs --release
+      - name: Run doc tests
+        run: cargo test --all-features --doc
+      - name: Check Documentation
+        run: cargo doc --all-features --no-deps --document-private-items

--- a/client-request-tests/tests/fixtures/memcheck-reqs-test.armv7.stderr
+++ b/client-request-tests/tests/fixtures/memcheck-reqs-test.armv7.stderr
@@ -1,5 +1,5 @@
 Handling new value --leak-check=summary for option --leak-check=summary
-Searching for pointers to 3 not-freed blocks
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
 LEAK SUMMARY:
@@ -11,11 +11,11 @@ suppressed: <__FILTER__> bytes in <__FILTER__> blocks
 Reachable blocks (those to which a pointer was found) are not shown.
 To see them, rerun with: --leak-check=full --show-leak-kinds=all
 
-First value of leaked memory: 1
-Searching for pointers to 4 not-freed blocks
+First value of leaked memory: <__NUMBER__>
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
-4 bytes in 1 blocks are definitely lost in loss record 1 of 4
+<__NUMBER__> bytes in <__NUMBER__> blocks are definitely lost in loss record <__NUMBER__> of <__NUMBER__>
 <__BACKTRACE__>
 
 LEAK SUMMARY:
@@ -27,8 +27,8 @@ suppressed: <__FILTER__> bytes in <__FILTER__> blocks
 Reachable blocks (those to which a pointer was found) are not shown.
 To see them, rerun with: --leak-check=full --show-leak-kinds=all
 
-First value of leaked memory: 1
-Searching for pointers to 5 not-freed blocks
+First value of leaked memory: <__NUMBER__>
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
 LEAK SUMMARY:
@@ -42,10 +42,10 @@ To see them, rerun with: --leak-check=full --show-leak-kinds=all
 
 
 HEAP SUMMARY:
-in use at exit: 8 bytes in 2 blocks
+in use at exit: <__NUMBER__> bytes in <__NUMBER__> blocks
 total heap usage: <__FILTER__>
 
-Searching for pointers to 2 not-freed blocks
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
 LEAK SUMMARY:
@@ -56,4 +56,4 @@ still reachable: <__FILTER__> bytes in <__FILTER__> blocks
 suppressed: <__FILTER__> bytes in <__FILTER__> blocks
 Rerun with --leak-check=full to see details of leaked memory
 
-ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
+ERROR SUMMARY: <__NUMBER__> errors from <__NUMBER__> contexts (suppressed: <__NUMBER__> from <__NUMBER__>)

--- a/client-request-tests/tests/fixtures/memcheck-reqs-test.stderr
+++ b/client-request-tests/tests/fixtures/memcheck-reqs-test.stderr
@@ -1,5 +1,5 @@
 Handling new value --leak-check=summary for option --leak-check=summary
-Searching for pointers to 3 not-freed blocks
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
 LEAK SUMMARY:
@@ -11,11 +11,11 @@ suppressed: <__FILTER__> bytes in <__FILTER__> blocks
 Reachable blocks (those to which a pointer was found) are not shown.
 To see them, rerun with: --leak-check=full --show-leak-kinds=all
 
-First value of leaked memory: 1
-Searching for pointers to 4 not-freed blocks
+First value of leaked memory: <__NUMBER__>
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
-4 bytes in 1 blocks are definitely lost in loss record 1 of 4
+<__NUMBER__> bytes in <__NUMBER__> blocks are definitely lost in loss record <__NUMBER__> of <__NUMBER__>
 <__BACKTRACE__>
 
 LEAK SUMMARY:
@@ -27,11 +27,11 @@ suppressed: <__FILTER__> bytes in <__FILTER__> blocks
 Reachable blocks (those to which a pointer was found) are not shown.
 To see them, rerun with: --leak-check=full --show-leak-kinds=all
 
-First value of leaked memory: 1
-Searching for pointers to 5 not-freed blocks
+First value of leaked memory: <__NUMBER__>
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
-4 (+4) bytes in 1 (+1) blocks are definitely lost in new loss record 2 of 5
+<__NUMBER__> (<__NUMBER__>) bytes in <__NUMBER__> (<__NUMBER__>) blocks are definitely lost in new loss record <__NUMBER__> of <__NUMBER__>
 <__BACKTRACE__>
 
 LEAK SUMMARY:
@@ -45,10 +45,10 @@ To see them, rerun with: --leak-check=full --show-leak-kinds=all
 
 
 HEAP SUMMARY:
-in use at exit: 8 bytes in 2 blocks
+in use at exit: <__NUMBER__> bytes in <__NUMBER__> blocks
 total heap usage: <__FILTER__>
 
-Searching for pointers to 2 not-freed blocks
+Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
 LEAK SUMMARY:
@@ -59,4 +59,4 @@ still reachable: <__FILTER__> bytes in <__FILTER__> blocks
 suppressed: <__FILTER__> bytes in <__FILTER__> blocks
 Rerun with --leak-check=full to see details of leaked memory
 
-ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
+ERROR SUMMARY: <__NUMBER__> errors from <__NUMBER__> contexts (suppressed: <__NUMBER__> from <__NUMBER__>)

--- a/client-request-tests/tests/fixtures/valgrind-reqs-test.freebsd.stderr
+++ b/client-request-tests/tests/fixtures/valgrind-reqs-test.freebsd.stderr
@@ -10,7 +10,16 @@ HEAP SUMMARY:
 in use at exit: <__NUMBER__> bytes in <__NUMBER__> blocks
 total heap usage: <__FILTER__>
 
-All heap blocks were freed -- no leaks are possible
+Searching for pointers to <__NUMBER__> not-freed blocks
+Checked <__FILTER__> bytes
+
+LEAK SUMMARY:
+definitely lost: <__FILTER__> bytes in <__FILTER__> blocks
+indirectly lost: <__FILTER__> bytes in <__FILTER__> blocks
+possibly lost: <__FILTER__> bytes in <__FILTER__> blocks
+still reachable: <__FILTER__> bytes in <__FILTER__> blocks
+suppressed: <__FILTER__> bytes in <__FILTER__> blocks
+Rerun with --leak-check=full to see details of leaked memory
 
 ERROR SUMMARY: <__NUMBER__> errors from <__NUMBER__> contexts (suppressed: <__NUMBER__> from <__NUMBER__>)
 

--- a/client-request-tests/tests/test_client_requests/valgrind.rs
+++ b/client-request-tests/tests/test_client_requests/valgrind.rs
@@ -1,3 +1,5 @@
+use std::io::{stderr, Write};
+
 use crate::common;
 
 #[test]
@@ -18,10 +20,31 @@ fn test_valgrind_reqs_when_running_on_valgrind() {
             common::get_test_bin_path("valgrind-reqs-test").display()
         ),
     ]);
-    cmd.assert()
-        .code(1)
-        .stdout("")
-        .stderr(predicates::str::diff(common::get_fixture_as_string(
-            "valgrind-reqs-test.stderr",
-        )));
+
+    let expected_code = 1;
+    match cmd.assert().try_code(expected_code) {
+        Ok(assert) => {
+            let fixture_string = if cfg!(target_os = "freebsd") {
+                common::get_fixture_as_string("valgrind-reqs-test.freebsd.stderr")
+            } else {
+                common::get_fixture_as_string("valgrind-reqs-test.stderr")
+            };
+            assert
+                .stdout("")
+                .stderr(predicates::str::diff(fixture_string));
+        }
+        Err(error) => {
+            let assert = error.assert();
+            let output = assert.get_output();
+
+            let mut err = stderr();
+            writeln!(err, "Unexpected exit code: STDERR:").unwrap();
+            err.write_all(&output.stderr).unwrap();
+            panic!(
+                "Assertion of exit code failed: Actual: {}, Expected: {}",
+                &output.status.code().unwrap(),
+                expected_code
+            )
+        }
+    }
 }

--- a/iai-callgrind-runner/src/util.rs
+++ b/iai-callgrind-runner/src/util.rs
@@ -95,14 +95,18 @@ pub fn write_all_to_stderr(bytes: &[u8]) {
 pub fn copy_directory(source: &Path, dest: &Path, follow_symlinks: bool) -> Result<()> {
     let cp = resolve_binary_path("cp")?;
     let mut command = Command::new(&cp);
+
+    // Using short options ensures compatibility with FreeBSD and Linux
     if follow_symlinks {
-        command.args(["-H", "--dereference"]);
+        // -H: Follow command-line symbolic links
+        // -L: always follow symbolic links in SOURCE
+        command.args(["-H", "-L"]);
     }
-    command.args([
-        "--verbose",
-        "--recursive",
-        "--preserve=mode,ownership,timestamps",
-    ]);
+
+    // -v: Verbose
+    // -R: Recursive
+    // -p: preserve timestamps, file mode, ownership
+    command.args(["-v", "-R", "-p"]);
     command.arg(source);
     command.arg(dest);
     let (stdout, stderr) = command

--- a/scripts/freebsd_build_and_test.sh
+++ b/scripts/freebsd_build_and_test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+set -e
+
+# shellcheck disable=SC1090
+. ~/.cargo/env
+
+echo Prepare
+cargo +stable install cargo-binstall
+cargo +stable binstall --no-confirm cargo-hack
+
+cargo update
+
+echo Build with the feature powerset
+just build-hack
+
+# This excludes the ui tests
+echo Run normal tests
+cargo test --workspace --exclude client-request-tests
+
+echo Run client request tests
+cargo test -p client-request-tests --test tests --release -- --nocapture
+
+echo Run benchmark tests
+just full-bench-test-all

--- a/scripts/freebsd_print_info.sh
+++ b/scripts/freebsd_print_info.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -e
+
+# shellcheck disable=SC1090
+. ~/.cargo/env
+
+pwd
+ls -lah
+whoami
+env
+freebsd-version
+
+valgrind --version
+
+rustup --version
+rustup show
+rustup component list --installed
+rustc --version --verbose

--- a/scripts/freebsd_run_tests.sh
+++ b/scripts/freebsd_run_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+# spell-checker:ignore nocapture
+
+set -e
+
+# shellcheck disable=SC1090
+. ~/.cargo/env
+
+cargo test -p client-request-tests --test tests --release -- --nocapture


### PR DESCRIPTION
This pr also adds running the build and all tests on FreeBSD