### PR TITLE
Support comparing library benchmark functions by `#[bench]` id (#37)

### DIFF
--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -101,6 +101,10 @@ name = "test_lib_bench_groups"
 
 [[bench]]
 harness = false
+name = "test_lib_bench_compare"
+
+[[bench]]
+harness = false
 name = "test_lib_bench_groups_envs"
 
 [[bench]]

--- a/benchmark-tests/benches/test_lib_bench_cache_sim.stdout.2
+++ b/benchmark-tests/benches/test_lib_bench_cache_sim.stdout.2
@@ -2,7 +2,7 @@ test_lib_bench_cache_sim::bench_cache_sim::bench_with_cache_sim with_10:setup_wo
   Instructions:                    |                (No change)
   L1 Hits:                         |                (No change)
   L2 Hits:                         |                (No change)
-  RAM Hits:                        |                (No change)
+  RAM Hits:                        |                (         )
   Total read+write:                |                (No change)
   Estimated Cycles:                |                (No change)
 test_lib_bench_cache_sim::bench_cache_sim::bench_without_cache_sim with_10:setup_worst_case_array(10)

--- a/benchmark-tests/benches/test_lib_bench_compare.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench_compare.conf.yml
@@ -1,0 +1,6 @@
+groups:
+  - runs:
+      - args: []
+        expected:
+          files: test_lib_bench_compare.expected.1.yml
+          stdout: test_lib_bench_compare.stdout.1

--- a/benchmark-tests/benches/test_lib_bench_compare.expected.1.yml
+++ b/benchmark-tests/benches/test_lib_bench_compare.expected.1.yml
@@ -1,0 +1,159 @@
+data:
+  - group: bubble_sort_compare_one
+    function: bench_bubble_sort_best_case
+    id: case_3
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.case_3.log
+        - callgrind.bench_bubble_sort_best_case.case_3.out
+        - summary.json
+  - group: bubble_sort_compare_one
+    function: bench_bubble_sort_best_case
+    id: multiple_0
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.multiple_0.log
+        - callgrind.bench_bubble_sort_best_case.multiple_0.out
+        - summary.json
+  - group: bubble_sort_compare_one
+    function: bench_bubble_sort_best_case
+    id: multiple_1
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.multiple_1.log
+        - callgrind.bench_bubble_sort_best_case.multiple_1.out
+        - summary.json
+  - group: bubble_sort_compare_two
+    function: bench_bubble_sort_best_case
+    id: case_3
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.case_3.log
+        - callgrind.bench_bubble_sort_best_case.case_3.out
+        - summary.json
+  - group: bubble_sort_compare_two
+    function: bench_bubble_sort_best_case
+    id: multiple_0
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.multiple_0.log
+        - callgrind.bench_bubble_sort_best_case.multiple_0.out
+        - summary.json
+  - group: bubble_sort_compare_two
+    function: bench_bubble_sort_best_case
+    id: multiple_1
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.multiple_1.log
+        - callgrind.bench_bubble_sort_best_case.multiple_1.out
+        - summary.json
+  - group: bubble_sort_compare_two
+    function: bench_bubble_sort_worst_case
+    id: case_3
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_worst_case.case_3.log
+        - callgrind.bench_bubble_sort_worst_case.case_3.out
+        - summary.json
+  - group: bubble_sort_compare_two
+    function: bench_bubble_sort_worst_case
+    id: multiple_0
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_worst_case.multiple_0.log
+        - callgrind.bench_bubble_sort_worst_case.multiple_0.out
+        - summary.json
+  - group: bubble_sort_compare_two
+    function: bench_bubble_sort_worst_case
+    id: multiple_1
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_worst_case.multiple_1.log
+        - callgrind.bench_bubble_sort_worst_case.multiple_1.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_best_case
+    id: case_3
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.case_3.log
+        - callgrind.bench_bubble_sort_best_case.case_3.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_best_case
+    id: multiple_0
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.multiple_0.log
+        - callgrind.bench_bubble_sort_best_case.multiple_0.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_best_case
+    id: multiple_1
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_best_case.multiple_1.log
+        - callgrind.bench_bubble_sort_best_case.multiple_1.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_worst_case
+    id: case_3
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_worst_case.case_3.log
+        - callgrind.bench_bubble_sort_worst_case.case_3.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_worst_case
+    id: multiple_0
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_worst_case.multiple_0.log
+        - callgrind.bench_bubble_sort_worst_case.multiple_0.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_worst_case
+    id: multiple_1
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_worst_case.multiple_1.log
+        - callgrind.bench_bubble_sort_worst_case.multiple_1.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_mixed_case
+    id: case_3
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_mixed_case.case_3.log
+        - callgrind.bench_bubble_sort_mixed_case.case_3.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_mixed_case
+    id: no_compare_multiple_0
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_mixed_case.no_compare_multiple_0.log
+        - callgrind.bench_bubble_sort_mixed_case.no_compare_multiple_0.out
+        - summary.json
+  - group: bubble_sort_compare_three
+    function: bench_bubble_sort_mixed_case
+    id: no_compare_multiple_1
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_mixed_case.no_compare_multiple_1.log
+        - callgrind.bench_bubble_sort_mixed_case.no_compare_multiple_1.out
+        - summary.json
+  - group: bubble_sort_compare_no_id
+    function: bench_bubble_sort_no_id_1
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_no_id_1.log
+        - callgrind.bench_bubble_sort_no_id_1.out
+        - summary.json
+  - group: bubble_sort_compare_no_id
+    function: bench_bubble_sort_no_id_2
+    expected:
+      files:
+        - callgrind.bench_bubble_sort_no_id_2.log
+        - callgrind.bench_bubble_sort_no_id_2.out
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench_compare.rs
+++ b/benchmark-tests/benches/test_lib_bench_compare.rs
@@ -1,0 +1,69 @@
+use std::hint::black_box;
+
+use benchmark_tests::{bubble_sort, setup_worst_case_array};
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+
+#[library_benchmark]
+#[bench::case_3(vec![1, 2, 3])]
+#[benches::multiple(args = [vec![1, 2], vec![1, 2, 3, 4]])]
+fn bench_bubble_sort_best_case(input: Vec<i32>) -> Vec<i32> {
+    black_box(bubble_sort(input))
+}
+
+#[library_benchmark]
+#[bench::case_3(vec![3, 2, 1])]
+#[benches::multiple(args = [vec![2, 1], vec![4, 3, 2, 1]])]
+fn bench_bubble_sort_worst_case(input: Vec<i32>) -> Vec<i32> {
+    black_box(bubble_sort(input))
+}
+
+#[library_benchmark]
+#[bench::case_3(vec![2, 3, 1])]
+#[benches::no_compare_multiple(args = [vec![2, 1], vec![2, 4, 3, 1]])]
+fn bench_bubble_sort_mixed_case(input: Vec<i32>) -> Vec<i32> {
+    black_box(bubble_sort(input))
+}
+
+library_benchmark_group!(
+    name = bubble_sort_compare_one;
+    compare_by_id = true;
+    benchmarks = bench_bubble_sort_best_case
+);
+
+library_benchmark_group!(
+    name = bubble_sort_compare_two;
+    compare_by_id = true;
+    benchmarks = bench_bubble_sort_best_case, bench_bubble_sort_worst_case
+);
+
+library_benchmark_group!(
+    name = bubble_sort_compare_three;
+    compare_by_id = true;
+    benchmarks =
+        bench_bubble_sort_best_case, bench_bubble_sort_worst_case, bench_bubble_sort_mixed_case
+);
+
+#[library_benchmark]
+fn bench_bubble_sort_no_id_1() -> Vec<i32> {
+    black_box(bubble_sort(vec![]))
+}
+
+#[library_benchmark]
+fn bench_bubble_sort_no_id_2() -> Vec<i32> {
+    black_box(bubble_sort(black_box(setup_worst_case_array(6))))
+}
+
+library_benchmark_group!(
+    name = bubble_sort_compare_no_id;
+    compare_by_id = true;
+    benchmarks =
+        bench_bubble_sort_no_id_1,
+        bench_bubble_sort_no_id_2,
+);
+
+main!(
+    library_benchmark_groups = bubble_sort_compare_one,
+    bubble_sort_compare_two,
+    bubble_sort_compare_three,
+    bubble_sort_compare_no_id,
+);

--- a/benchmark-tests/benches/test_lib_bench_compare.stdout.1
+++ b/benchmark-tests/benches/test_lib_bench_compare.stdout.1
@@ -1,0 +1,196 @@
+test_lib_bench_compare::bubble_sort_compare_one::bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_one::bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_one::bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_worst_case case_3:vec! [3, 2, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+  Comparison with bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                    |                (-       %) [-       x]
+  L1 Hits:                         |                (-       %) [-       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (-       %) [-       x]
+  Estimated Cycles:                |                (-       %) [-       x]
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_worst_case multiple_0:vec! [2, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+  Comparison with bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+  Instructions:                    |                (-       %) [-       x]
+  L1 Hits:                         |                (-       %) [-       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (-       %) [-       x]
+  Estimated Cycles:                |                (-       %) [-       x]
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_worst_case multiple_1:vec! [4, 3, 2, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+  Comparison with bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+  Instructions:                    |                (-       %) [-       x]
+  L1 Hits:                         |                (-       %) [-       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (-       %) [-       x]
+  Estimated Cycles:                |                (-       %) [-       x]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_worst_case case_3:vec! [3, 2, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+  Comparison with bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                    |                (-       %) [-       x]
+  L1 Hits:                         |                (-       %) [-       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (-       %) [-       x]
+  Estimated Cycles:                |                (-       %) [-       x]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_worst_case multiple_0:vec! [2, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+  Comparison with bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+  Instructions:                    |                (-       %) [-       x]
+  L1 Hits:                         |                (-       %) [-       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (-       %) [-       x]
+  Estimated Cycles:                |                (-       %) [-       x]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_worst_case multiple_1:vec! [4, 3, 2, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+  Comparison with bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+  Instructions:                    |                (-       %) [-       x]
+  L1 Hits:                         |                (-       %) [-       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (-       %) [-       x]
+  Estimated Cycles:                |                (-       %) [-       x]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_mixed_case case_3:vec! [2, 3, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+  Comparison with bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                    |                (-       %) [-       x]
+  L1 Hits:                         |                (-       %) [-       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (-       %) [-       x]
+  Estimated Cycles:                |                (-       %) [-       x]
+  Comparison with bench_bubble_sort_worst_case case_3:vec! [3, 2, 1]
+  Instructions:                    |                (+       %) [+       x]
+  L1 Hits:                         |                (+       %) [+       x]
+  L2 Hits:                         |                (No change)
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (+       %) [+       x]
+  Estimated Cycles:                |                (+       %) [+       x]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_mixed_case no_compare_multiple_0:vec! [2, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_mixed_case no_compare_multiple_1:vec! [2, 4, 3, 1]
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_no_id::bench_bubble_sort_no_id_1
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_compare::bubble_sort_compare_no_id::bench_bubble_sort_no_id_2
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)

--- a/benchmark-tests/benches/test_lib_bench_single.stdout.3
+++ b/benchmark-tests/benches/test_lib_bench_single.stdout.3
@@ -3,6 +3,6 @@ test_bench::bench_group::bench_bubble_sort worst_case:setup_worst_case_array(300
   Instructions:                    |                (+       %) [+       x]
   L1 Hits:                         |                (+       %) [+       x]
   L2 Hits:                         |                (+       %) [+       x]
-  RAM Hits:                        |                (+       %) [+       x]
+  RAM Hits:                        |                (         )
   Total read+write:                |                (+       %) [+       x]
   Estimated Cycles:                |                (+       %) [+       x]

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -290,36 +290,66 @@ impl BenchmarkOutput {
                     }
                 };
                 write!(string, "{desc}{comp1}|{comp2}").unwrap();
-                if caps.name("diff_percent").is_some() {
-                    let white1 = caps.name("white1").unwrap().as_str();
-                    let percent = caps.name("percent").unwrap().as_str();
-                    let num = &percent[1..percent.len() - 2];
-                    if num.parse::<f64>().is_ok() {
-                        write!(
-                            string,
-                            "{white1}({}{}%)",
-                            num.chars().next().unwrap(),
-                            " ".repeat(num.len() - 1)
-                        )
-                        .unwrap();
-                    } else {
-                        write!(string, "{white1}{percent}").unwrap();
+
+                // RAM Hits events are very unreliable across different systems, so to keep the
+                // output comparison more reliable we change this line from (for example)
+                //
+                //   RAM Hits:             179|209             (-14.3541%) [-1.16760x]
+                //   RAM Hits:             179|179             (No Change)
+                //
+                // to
+                //
+                //   RAM Hits:             179|209             (         )
+                //
+                // and
+                //
+                //   RAM Hits:             179|N/A             (*********)
+                //
+                // to
+                //
+                //   RAM Hits:                |N/A             (*********)
+                if desc.starts_with("  RAM Hits") {
+                    if caps.name("diff_percent").is_some() {
+                        let white1 = caps.name("white1").unwrap().as_str();
+                        let percent = caps.name("percent").unwrap().as_str();
+                        if percent == "(*********)" {
+                            write!(string, "{white1}{percent}").unwrap();
+                        } else {
+                            write!(string, "{white1}(         )").unwrap();
+                        }
                     }
-                }
-                if caps.name("diff_factor").is_some() {
-                    let white2 = caps.name("white2").unwrap().as_str();
-                    let factor = caps.name("factor").unwrap().as_str();
-                    let num = &factor[1..factor.len() - 2];
-                    if num.parse::<f64>().is_ok() {
-                        write!(
-                            string,
-                            "{white2}[{}{}x]",
-                            num.chars().next().unwrap(),
-                            " ".repeat(num.len() - 1)
-                        )
-                        .unwrap();
-                    } else {
-                        write!(string, "{white2}{factor}").unwrap();
+                } else {
+                    if caps.name("diff_percent").is_some() {
+                        let white1 = caps.name("white1").unwrap().as_str();
+                        let percent = caps.name("percent").unwrap().as_str();
+                        let num = &percent[1..percent.len() - 2];
+                        if num.parse::<f64>().is_ok() {
+                            write!(
+                                string,
+                                "{white1}({}{}%)",
+                                num.chars().next().unwrap(),
+                                " ".repeat(num.len() - 1)
+                            )
+                            .unwrap();
+                        } else {
+                            write!(string, "{white1}{percent}").unwrap();
+                        }
+                    }
+                    if caps.name("diff_factor").is_some() {
+                        let white2 = caps.name("white2").unwrap().as_str();
+                        let factor = caps.name("factor").unwrap().as_str();
+                        let num = &factor[1..factor.len() - 2];
+                        if num.parse::<f64>().is_ok() {
+                            write!(
+                                string,
+                                "{white2}[{}{}x]",
+                                num.chars().next().unwrap(),
+                                " ".repeat(num.len() - 1)
+                            )
+                            .unwrap();
+                        } else {
+                            write!(string, "{white2}{factor}").unwrap();
+                        }
                     }
                 }
                 writeln!(result, "{string}").unwrap();

--- a/benchmark-tests/src/lib.rs
+++ b/benchmark-tests/src/lib.rs
@@ -2,6 +2,26 @@ use std::ffi::OsStr;
 use std::io;
 use std::process::Output;
 
+// This function is used to create a worst case array we want to sort with our implementation of
+// bubble sort
+pub fn setup_worst_case_array(start: i32) -> Vec<i32> {
+    if start.is_negative() {
+        (start..0).rev().collect()
+    } else {
+        (0..start).rev().collect()
+    }
+}
+
+// This function is used to create a best case array we want to sort with our implementation of
+// bubble sort
+pub fn setup_best_case_array(start: i32) -> Vec<i32> {
+    if start.is_negative() {
+        (start..0).collect()
+    } else {
+        (0..start).collect()
+    }
+}
+
 pub fn bubble_sort(mut array: Vec<i32>) -> Vec<i32> {
     for i in 0..array.len() {
         for j in 0..array.len() - i - 1 {

--- a/iai-callgrind-runner/schemas/summary.v1.schema.json
+++ b/iai-callgrind-runner/schemas/summary.v1.schema.json
@@ -6,6 +6,7 @@
   "required": [
     "benchmark_exe",
     "benchmark_file",
+    "function_name",
     "kind",
     "module_path",
     "package_dir",
@@ -36,6 +37,10 @@
     "details": {
       "description": "More details describing this benchmark run",
       "type": ["string", "null"]
+    },
+    "function_name": {
+      "description": "The name of the function under test",
+      "type": "string"
     },
     "id": {
       "description": "The user provided id of this benchmark",

--- a/iai-callgrind-runner/src/api.rs
+++ b/iai-callgrind-runner/src/api.rs
@@ -212,6 +212,7 @@ pub struct LibraryBenchmarkConfig {
 pub struct LibraryBenchmarkGroup {
     pub id: Option<String>,
     pub config: Option<LibraryBenchmarkConfig>,
+    pub compare: bool,
     pub benches: Vec<LibraryBenchmarkBenches>,
 }
 

--- a/iai-callgrind-runner/src/runner/costs.rs
+++ b/iai-callgrind-runner/src/runner/costs.rs
@@ -74,6 +74,10 @@ impl<K: Hash + Eq + Display + Clone> Costs<K> {
     pub fn empty() -> Self {
         Costs(IndexMap::new())
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 pub trait Summarize: Hash + Eq + Clone {

--- a/iai-callgrind-runner/src/runner/format.rs
+++ b/iai-callgrind-runner/src/runner/format.rs
@@ -9,6 +9,12 @@ use super::tool::ValgrindTool;
 use crate::api::EventKind;
 use crate::util::{to_string_signed_short, truncate_str_utf8};
 
+pub struct ComparisonHeader {
+    pub function_name: String,
+    pub id: String,
+    pub details: Option<String>,
+}
+
 pub struct Header {
     pub module_path: String,
     pub id: Option<String>,
@@ -48,6 +54,43 @@ pub enum OutputFormat {
 #[derive(Clone)]
 pub struct VerticalFormat {
     event_kinds: Vec<EventKind>,
+}
+
+impl ComparisonHeader {
+    pub fn new<T, U, V>(function_name: T, id: U, details: Option<V>) -> Self
+    where
+        T: Into<String>,
+        U: Into<String>,
+        V: Into<String>,
+    {
+        Self {
+            function_name: function_name.into(),
+            id: id.into(),
+            details: details.map(Into::into),
+        }
+    }
+
+    pub fn print(&self) {
+        println!("{self}");
+    }
+}
+
+impl Display for ComparisonHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "  {} {} {}",
+            "Comparison with".yellow().bold(),
+            self.function_name.green(),
+            self.id.cyan()
+        )?;
+
+        if let Some(details) = &self.details {
+            write!(f, ":{}", details.blue().bold())?;
+        }
+
+        Ok(())
+    }
 }
 
 impl Header {

--- a/iai-callgrind/src/macros.rs
+++ b/iai-callgrind/src/macros.rs
@@ -735,7 +735,7 @@ binary_benchmark_group!(name = some_ident; benchmark = |"my_exe", group: &mut Bi
 /// library_benchmark_group!(
 ///     name = my_group;
 ///     config = LibraryBenchmarkConfig::default();
-///     compare = false;
+///     compare_by_id = false;
 ///     benchmarks = some_func
 /// );
 /// # fn main() {
@@ -744,11 +744,10 @@ binary_benchmark_group!(name = some_ident; benchmark = |"my_exe", group: &mut Bi
 ///
 /// * `__name__` (mandatory): A unique name used to identify the group for the `main!` macro
 /// * `__config__` (optional): A [`crate::LibraryBenchmarkConfig`] which is applied to all
-///   benchmarks within the same group.
-/// * `__compare_by_id__` (optional): The default is false. If true, the two benchmark functions
-///   specified with the `benchmarks` argument are compared with each other as long as the ids (the
-///   part after the `::` in `#[bench::id(...)]`) match. If true, the number of benchmark functions
-///   must be exactly two.
+/// benchmarks within the same group.
+/// * `__compare_by_id__` (optional): The default is false. If true, all benches in the benchmark
+/// functions specified with the `benchmarks` argument are compared with each other as long as the
+/// ids (the part after the `::` in `#[bench::id(...)]`) match.
 #[macro_export]
 macro_rules! library_benchmark_group {
     (

--- a/iai-callgrind/src/macros.rs
+++ b/iai-callgrind/src/macros.rs
@@ -301,6 +301,7 @@ macro_rules! main {
                 let mut group = $crate::internal::InternalLibraryBenchmarkGroup {
                     id: Some(stringify!($group).to_owned()),
                     config: $group::get_config(),
+                    compare: $group::compare(),
                     benches: vec![]
                 };
                 for (bench_name, get_config, macro_lib_benches) in $group::BENCHES {
@@ -734,20 +735,25 @@ binary_benchmark_group!(name = some_ident; benchmark = |"my_exe", group: &mut Bi
 /// library_benchmark_group!(
 ///     name = my_group;
 ///     config = LibraryBenchmarkConfig::default();
+///     compare = false;
 ///     benchmarks = some_func
 /// );
 /// # fn main() {
 /// # }
 /// ```
 ///
-/// * __name__ (mandatory): A unique name used to identify the group for the `main!` macro
-/// * __config__ (optional): A [`crate::LibraryBenchmarkConfig`] which is applied to all benchmarks
-///   within
-/// the same group.
+/// * `__name__` (mandatory): A unique name used to identify the group for the `main!` macro
+/// * `__config__` (optional): A [`crate::LibraryBenchmarkConfig`] which is applied to all
+///   benchmarks within the same group.
+/// * `__compare_by_id__` (optional): The default is false. If true, the two benchmark functions
+///   specified with the `benchmarks` argument are compared with each other as long as the ids (the
+///   part after the `::` in `#[bench::id(...)]`) match. If true, the number of benchmark functions
+///   must be exactly two.
 #[macro_export]
 macro_rules! library_benchmark_group {
     (
         $( config = $config:expr ; $(;)* )?
+        $( compare_by_id = $compare:literal ; $(;)* )?
         benchmarks = $( $function:ident ),+
     ) => {
         compile_error!("A library_benchmark_group! needs a name\n\nlibrary_benchmark_group!(name = some_ident; benchmarks = ...);");
@@ -755,6 +761,7 @@ macro_rules! library_benchmark_group {
     (
         name = $name:ident;
         $( config = $config:expr ; $(;)* )?
+        $( compare_by_id = $compare:literal ; $(;)* )?
         benchmarks =
     ) => {
         compile_error!(
@@ -765,6 +772,7 @@ macro_rules! library_benchmark_group {
     (
         name = $name:ident; $(;)*
         $( config = $config:expr ; $(;)* )?
+        $( compare_by_id = $compare:literal ; $(;)* )?
         benchmarks = $( $function:ident ),+ $(,)*
     ) => {
         mod $name {
@@ -784,12 +792,22 @@ macro_rules! library_benchmark_group {
                 ),+
             ];
 
+            #[inline(never)]
             pub fn get_config() -> Option<$crate::internal::InternalLibraryBenchmarkConfig> {
                 let mut config: Option<$crate::internal::InternalLibraryBenchmarkConfig> = None;
                 $(
                     config = Some($config.into());
                 )?
                 config
+            }
+
+            #[inline(never)]
+            pub fn compare() -> bool {
+                let mut comp: bool = false;
+                $(
+                    comp = $compare;
+                )?
+                comp
             }
 
             #[inline(never)]

--- a/iai-callgrind/tests/ui/test_main_invalid_library_benchmark_groups.stderr
+++ b/iai-callgrind/tests/ui/test_main_invalid_library_benchmark_groups.stderr
@@ -1,3 +1,19 @@
+error[E0425]: cannot find function `compare` in module `some_func`
+  --> tests/ui/test_main_invalid_library_benchmark_groups.rs:6:5
+   |
+6  |     main!(library_benchmark_groups = some_func);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `some_func`
+   |
+note: function `crate::test_main_when_invalid_config::my_group::compare` exists but is inaccessible
+  --> tests/ui/test_main_invalid_library_benchmark_groups.rs:14:5
+   |
+14 | /     library_benchmark_group!(
+15 | |         name = my_group;
+16 | |         benchmarks = some_func
+17 | |     );
+   | |_____^ not accessible
+   = note: this error originates in the macro `main` which comes from the expansion of the macro `library_benchmark_group` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0603]: function import `run` is private
  --> src/macros.rs
   |


### PR DESCRIPTION
This pr adds support for comparing benchmark functions specified in a `library_benchmark_group!`. Only the benches with the same id of the `#[bench::id(...)]` attribute are compared.

Closes #37