### PR TITLE
chore: mark build deps as optional

### DIFF
--- a/iai-callgrind/Cargo.toml
+++ b/iai-callgrind/Cargo.toml
@@ -22,14 +22,20 @@ benchmark = [
   "dep:iai-callgrind-runner",
 ]
 client_requests = ["client_requests_defs"]
-client_requests_defs = ["dep:cty", "dep:cfg-if"]
+client_requests_defs = [
+  "dep:cty",
+  "dep:cfg-if",
+  "dep:bindgen",
+  "dep:cc",
+  "dep:regex",
+]
 default = ["benchmark"]
 ui_tests = []
 
 [build-dependencies]
-bindgen = { workspace = true }
-cc = { workspace = true }
-regex = { workspace = true }
+bindgen = { workspace = true, optional = true }
+cc = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 features = ["client_requests_defs"]

--- a/iai-callgrind/build.rs
+++ b/iai-callgrind/build.rs
@@ -40,7 +40,7 @@ mod imp {
     }
 
     fn print_client_requests_support(value: &str) {
-        println!("cargo:rustc-check-cfg=cfg(client_requests_support,values(\"{value}\")");
+        println!("cargo:rustc-check-cfg=cfg(client_requests_support,values(\"{value}\"))");
         println!("cargo:rustc-cfg=client_requests_support=\"{value}\"");
     }
 

--- a/iai-callgrind/build.rs
+++ b/iai-callgrind/build.rs
@@ -7,6 +7,7 @@ mod imp {
     use std::path::PathBuf;
 
     use bindgen::{builder, Bindings};
+
     #[derive(Debug)]
     struct Target {
         arch: String,
@@ -39,6 +40,7 @@ mod imp {
     }
 
     fn print_client_requests_support(value: &str) {
+        println!("cargo:rustc-check-cfg=cfg(client_requests_support,values(\"{value}\")");
         println!("cargo:rustc-cfg=client_requests_support=\"{value}\"");
     }
 


### PR DESCRIPTION
`iai-callgrind`'s build dependencies are only used when the "client_requests_defs" feature is enabled, and as such should be marked optional to avoid compiling them when this feature is not enabled.

I have also included a fix to suppress cargo's `--check-cfg` warnings (beta, nightly only for now).