### PR TITLE
fix: Print rust-check-cfg only if rust version >= 1.80.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -679,6 +679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,7 +717,9 @@ dependencies = [
  "iai-callgrind-macros",
  "iai-callgrind-runner",
  "regex",
+ "strum",
  "trybuild",
+ "version-compare",
 ]
 
 [[package]]
@@ -1317,6 +1325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1520,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = { version = "1.0.79" }
 serde_yaml = { version = "0.9" }
 serial_test = { version = "3" }
 shlex = { version = "1.3" }
+strum = { version = "0.26", features = ["derive"] }
 syn = { version = "2.0.16", features = ["full", "extra-traits"] }
 tempfile = { version = "3" }
 trybuild = "1.0.18"

--- a/iai-callgrind/Cargo.toml
+++ b/iai-callgrind/Cargo.toml
@@ -28,6 +28,8 @@ client_requests_defs = [
   "dep:bindgen",
   "dep:cc",
   "dep:regex",
+  "dep:version-compare",
+  "dep:strum",
 ]
 default = ["benchmark"]
 ui_tests = []
@@ -36,6 +38,8 @@ ui_tests = []
 bindgen = { workspace = true, optional = true }
 cc = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
+version-compare = { workspace = true, optional = true }
+strum = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 features = ["client_requests_defs"]


### PR DESCRIPTION
Fix the `rust-check-cfg` iai-callgrind build script prints introduced in #175.

We need to check the currently active rust version (rust-check-cfg was introduced in 1.80), to avoid compiler warnings if `rust-check-cfg` is printed although the rust version is < 1.80. Also, the different values need to be printed in a single statement following the syntax `rust-check-cfg=cfg(key, values("value1","value2",...))`