### PR TITLE
Add teardown parameter to #[bench] and #[benches]. Add setup and teardown to #[library_benchmark].

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,6 @@
 # spell-checker:ignore taiki rustfmt binstall clippy taplo rustup nocapture
 # spell-checker:ignore nofile gnuabi armv gnueabi mipsel vmactions usesh proto
-# spell-checker:ignore tlsv connrefused
+# spell-checker:ignore tlsv connrefused copyback
 
 name: Build and Check
 
@@ -215,6 +215,8 @@ jobs:
         with:
           envs: "IAI_CALLGRIND_VALGRIND_INCLUDE IAI_CALLGRIND_VALGRIND_PATH"
           usesh: true
+          sync: rsync
+          copyback: false
           prepare: |
             pkg install -y valgrind curl llvm18 just npm-node22
             curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain stable --profile minimal -y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Compiler error when setup parameter was specified before args parameter and
+  number of elements of the args parameter did not match the number of arguments
+  of the benchmark function
+
 ## [0.11.1] - 2024-07-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* ([#192](https://github.com/iai-callgrind/iai-callgrind/pull/192)): The
+  `#[bench]` attribute now accepts a `setup` parameter similarly to the
+  `#[benches]` attribute. The `#[bench]` and `#[benches]` attribute accept a
+  new `teardown` parameter. The `teardown` function is called with the return
+  value of the benchmark function. The `#[library_benchmark]` attribute now
+  accepts a global `setup` and `teardown` parameter which are applied to all following
+  `#[bench]` and `#[benches]` attributes if they don't specify one of these
+  parameters themselves.
+
 ### Fixed
 
-* Compiler error when setup parameter was specified before args parameter and
-  number of elements of the args parameter did not match the number of arguments
-  of the benchmark function
+* ([#192](https://github.com/iai-callgrind/iai-callgrind/pull/192)): Fix a
+  wrongly issued compiler error when the setup parameter was specified before
+  the args parameter and the number of elements of the args parameter did not
+  match the number of arguments of the benchmark function.
+* ([#192](https://github.com/iai-callgrind/iai-callgrind/pull/192)): Fix the
+  error span of wrong user supplied argument types or wrong number of arguments.
+  The compiler errors now point to the exact location of any wrong arguments
+  instead of the generic call-site of the `#[library_benchmark]` attribute. If
+  there is a setup function involved, we leave it to the rust compiler to point
+  to the location of the setup function and the wrong arguments.
 
 ## [0.11.1] - 2024-07-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.50"
+version = "2.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f2890e9f6f068d927643e8d547931b537f21fd298e197c4837f1265b11e560"
+checksum = "14138c8a3dd9e14adeb406e5b2c74749c7ae638aa2f8a3a95497bf797f565490"
 dependencies = [
  "psl-types",
 ]
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1696,9 +1696,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.35"
+version = "2.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14138c8a3dd9e14adeb406e5b2c74749c7ae638aa2f8a3a95497bf797f565490"
+checksum = "20f2890e9f6f068d927643e8d547931b537f21fd298e197c4837f1265b11e560"
 dependencies = [
  "psl-types",
 ]
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1696,9 +1696,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ once_cell = { version = "1" }
 predicates = { version = "3" }
 pretty_assertions = "1.1"
 proc-macro-error = "1"
-proc-macro2 = "1.0.60"
-quote = "1.0.25"
+proc-macro2 = "1.0.63"
+quote = "1.0.28"
 regex = { version = "1.9" }
 rstest = ">=0.17, <0.20"
 sanitize-filename = { version = "0.5" }
@@ -55,7 +55,7 @@ serde_yaml = { version = "0.9" }
 serial_test = { version = "3" }
 shlex = { version = "1.3" }
 strum = { version = "0.26", features = ["derive"] }
-syn = { version = "2.0.16", features = ["full", "extra-traits"] }
+syn = { version = "2.0.32", features = ["full", "extra-traits"] }
 tempfile = { version = "3" }
 trybuild = "1.0.18"
 valico = { version = "4" }

--- a/README.md
+++ b/README.md
@@ -328,7 +328,76 @@ test_lib_bench_readme_example_fibonacci::bench_fibonacci_group::bench_fibonacci 
   Estimated Cycles:        22025983|35638757        (-38.1965%) [-1.61803x]
 ```
 
+##### The #[library_benchmark] attribute in more detail
+
+This attribute needs to be present on all benchmark functions specified in the
+`library_benchmark_group`. The benchmark function can then be further annotated
+with the `#[bench]` or `#[benches]` attributes.
+
+```rust
+#[library_benchmark]
+#[bench::first(21)]
+fn my_bench(value: u64) -> u64 {
+    // benchmark something
+}
+
+library_benchmark_group!(name = my_group; benchmarks = my_bench);
+```
+
+The following parameters are accepted:
+
+- `config`: Accepts a `LibraryBenchmarkConfig`
+- `setup`: A global setup function which is applied to all following `#[bench]`
+  and `#[benches]` attributes if not overwritten by a `setup` parameter of these
+  attributes.
+- `teardown`: Similar to `setup` but takes a global `teardown` function.
+
+A short example on the usage of the `setup` parameter:
+
+```rust
+fn my_setup(value: u64) -> String {
+     format!("{value}")
+}
+
+fn my_other_setup(value: u64) -> String {
+     format!("{}", value + 10)
+}
+
+#[library_benchmark(setup = my_setup)]
+#[bench::first(21)]
+#[benches::multiple(42, 84)]
+#[bench::last(args = (102), setup = my_other_setup)]
+fn my_bench(value: String) {
+    println!("{value}");
+}
+```
+
+Here, the benchmarks with the id `first` and `multiple` use the `my_setup`
+function, and `last` uses `my_other_setup`.
+
+##### The #[bench] attribute
+
+The basic structure is `#[bench::some_id(/* parameters */)]`. The part after the
+`::` must be an id unique within the same `#[library_benchmark]`. This attribute
+accepts the following parameters:
+
+- `args`: A tuple with a list of arguments which are passed to the
+  benchmark function. The parentheses also need to be present if there is only a
+  single argument (`#[bench::my_id(args = (10))]`).
+- `config`: Accepts a `LibraryBenchmarkConfig`
+- `setup`: A function which takes the arguments specified in the `args`
+  parameter and passes its return value to the benchmark function.
+- `teardown`: A function which takes the return value of the benchmark function.
+
+If no other parameters besides `args` are present you can simply pass the
+arguments as a list of values. Instead of `#[bench::my_id(args = (10, 20))]`,
+you could also use the shorter `#[bench::my_id(10, 20)]`.
+
 ##### Specify multiple benchmarks at once with the #[benches] attribute
+
+This attribute accepts the same parameters as the `#[bench]` attribute: `args`,
+`config`, `setup` and `teardown`. In contrast to the `args` parameter in
+`#[bench]`, `args` takes an array of arguments.
 
 Let's start with an example:
 

--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -117,4 +117,8 @@ name = "test_lib_bench_tools"
 
 [[bench]]
 harness = false
+name = "test_lib_bench_setup_and_teardown"
+
+[[bench]]
+harness = false
 name = "test_bench"

--- a/benchmark-tests/benches/test_lib_bench_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_lib_bench_setup_and_teardown.rs
@@ -1,0 +1,49 @@
+use std::hint::black_box;
+
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+
+fn setup_two_arguments(first: u64, second: u64) -> u64 {
+    first + second
+}
+
+fn setup_one_argument(value: u64) -> u64 {
+    value * value
+}
+
+fn teardown(tuple: (u64, u64)) {
+    let (result, expected) = tuple;
+    if result != expected {
+        panic!("Expected: {expected} but result was {result}");
+    }
+}
+
+#[library_benchmark]
+#[bench::with_setup(args = (2, 3), setup = setup_two_arguments)]
+#[bench::with_setup_first(setup = setup_two_arguments, args = (2, 3))]
+#[bench::with_teardown(args = (5), teardown = teardown)]
+fn bench(value: u64) -> (u64, u64) {
+    black_box((black_box(value * value), black_box(5)))
+}
+
+#[library_benchmark]
+#[benches::with_setup_one_argument(
+    args = [2,
+           setup_one_argument(5),
+           { let mut result = 0; for i in [2, 3] { result += i}; result }
+    ], setup = setup_one_argument)]
+fn benches_one_argument(value: u64) -> (u64, u64) {
+    black_box((black_box(value * value), black_box(5)))
+}
+
+#[library_benchmark]
+#[benches::with_setup(args = [(2, 3)], setup = setup_two_arguments)]
+fn benches_two_arguments(value: u64) -> (u64, u64) {
+    black_box((black_box(value * value), black_box(5)))
+}
+
+library_benchmark_group!(
+    name = bench_fibonacci_group;
+    benchmarks = bench, benches_one_argument, benches_two_arguments
+);
+
+main!(library_benchmark_groups = bench_fibonacci_group);

--- a/benchmark-tests/benches/test_lib_bench_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_lib_bench_setup_and_teardown.rs
@@ -10,40 +10,67 @@ fn setup_one_argument(value: u64) -> u64 {
     value * value
 }
 
-fn teardown(tuple: (u64, u64)) {
-    let (result, expected) = tuple;
+fn setup_no_argument() -> u64 {
+    9
+}
+
+fn teardown((result, expected): (u64, u64)) {
     if result != expected {
         panic!("Expected: {expected} but result was {result}");
     }
 }
 
 #[library_benchmark]
-#[bench::with_setup(args = (2, 3), setup = setup_two_arguments)]
-#[bench::with_setup_first(setup = setup_two_arguments, args = (2, 3))]
-#[bench::with_teardown(args = (5), teardown = teardown)]
-fn bench(value: u64) -> (u64, u64) {
-    black_box((black_box(value * value), black_box(5)))
+#[bench::no_argument(args = (), setup = setup_no_argument)]
+#[bench::one_argument(args = (3), setup = setup_one_argument)]
+#[bench::two_arguments(args = (3, 6), setup = setup_two_arguments)]
+#[bench::expression(args = ({
+        let mut result = 0;
+        for i in [2, 3] { result += i };
+        result
+    }), setup = setup_one_argument)]
+#[bench::setup_first_then_args(setup = setup_two_arguments, args = (3, 6))]
+fn bench_only_setup(value: u64) -> u64 {
+    black_box(value * value)
 }
 
 #[library_benchmark]
+#[bench::simple(args = (2, 3, 5), teardown = teardown)]
+#[bench::teardown_first_then_args(teardown = teardown, args = (2, 3, 5))]
+#[bench::with_args_expression(args = (2, 3, {
+        let mut result = 0;
+        for i in [2, 3] { result += i };
+        result
+    }), teardown = teardown)]
+fn bench_only_teardown(a: u64, b: u64, c: u64) -> (u64, u64) {
+    black_box((black_box(a + b), c))
+}
+
+#[library_benchmark]
+#[benches::no_argument(args = [], setup = setup_no_argument)]
 #[benches::with_setup_one_argument(
     args = [2,
            setup_one_argument(5),
            { let mut result = 0; for i in [2, 3] { result += i}; result }
     ], setup = setup_one_argument)]
-fn benches_one_argument(value: u64) -> (u64, u64) {
-    black_box((black_box(value * value), black_box(5)))
+fn benches_only_setup(value: u64) -> u64 {
+    black_box(value * value)
 }
 
 #[library_benchmark]
-#[benches::with_setup(args = [(2, 3)], setup = setup_two_arguments)]
-fn benches_two_arguments(value: u64) -> (u64, u64) {
-    black_box((black_box(value * value), black_box(5)))
+#[benches::simple(args = [(2, 3, 5)], teardown = teardown)]
+#[benches::teardown_first_then_args(teardown = teardown, args = [(2, 3, 5)])]
+#[benches::with_setup_one_argument(
+    args = [(2, 3, 5),
+            (2, 3, { let mut result = 0; for i in [2, 3] { result += i}; result })
+    ], teardown = teardown)]
+fn benches_only_teardown(a: u64, b: u64, c: u64) -> (u64, u64) {
+    black_box((black_box(a + b), c))
 }
 
 library_benchmark_group!(
     name = bench_fibonacci_group;
-    benchmarks = bench, benches_one_argument, benches_two_arguments
+    benchmarks = bench_only_setup, bench_only_teardown, benches_only_setup, bench_only_teardown
 );
 
 main!(library_benchmark_groups = bench_fibonacci_group);

--- a/iai-callgrind-macros/src/lib.rs
+++ b/iai-callgrind-macros/src/lib.rs
@@ -482,6 +482,11 @@ impl LibraryBenchmark {
         let ident = &item_fn.sig.ident;
         let export_name = format!("iai_callgrind::bench::{}", &item_fn.sig.ident);
         let config = self.config.render_as_code();
+
+        let inner = self.setup.render_as_code(&Args::default());
+        let call = quote! { std::hint::black_box(#ident(#inner)) };
+
+        let call = self.teardown.render_as_code(call);
         quote! {
             mod #ident {
                 use super::*;
@@ -503,7 +508,7 @@ impl LibraryBenchmark {
 
                 #[inline(never)]
                 pub fn wrapper() {
-                    let _ = std::hint::black_box(#ident());
+                    let _ = #call;
                 }
             }
         }

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.rs
@@ -9,4 +9,10 @@ fn bench2() {}
 #[library_benchmark(config = )]
 fn bench3() {}
 
+#[library_benchmark(setup = )]
+fn bench4() {}
+
+#[library_benchmark(teardown = )]
+fn bench4() {}
+
 fn main() {}

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.stderr
@@ -1,4 +1,4 @@
-error: Only the config argument is allowed
+error: Only the `config` argument is allowed
 
          = help: #[library_benchmark(config = ....)]
 

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.stderr
@@ -15,6 +15,22 @@ error: unexpected end of input, expected an expression
   |
   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: unexpected end of input, expected an expression
+  --> tests/ui/test_library_benchmark_invalid_arguments.rs:12:1
+   |
+12 | #[library_benchmark(setup = )]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of input, expected an expression
+  --> tests/ui/test_library_benchmark_invalid_arguments.rs:15:1
+   |
+15 | #[library_benchmark(teardown = )]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `InternalLibraryBenchmarkConfig: From<&str>` is not satisfied
  --> tests/ui/test_library_benchmark_invalid_arguments.rs:6:30
   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_arguments.stderr
@@ -1,6 +1,6 @@
-error: Only the `config` argument is allowed
+error: Invalid argument: wrong
 
-         = help: #[library_benchmark(config = ....)]
+         = help: Valid arguments are: `config`, `setup`, `teardown`
 
  --> tests/ui/test_library_benchmark_invalid_arguments.rs:3:21
   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_attributes.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_attributes.stderr
@@ -2,7 +2,7 @@ error: Invalid attribute: 'b'
 
          = help: Only the `bench` and the `benches` attribute are allowed
          = note: #[bench::my_id("with", "args")]
-                           or #[benches::my_id(args = [("with", "args"), ...)])]
+                           or #[benches::my_id(args = [("with", "args"), ...])]
 
  --> tests/ui/test_library_benchmark_invalid_attributes.rs:4:1
   |
@@ -13,7 +13,7 @@ error: Invalid attribute: 'inline'
 
          = help: Only the `bench` and the `benches` attribute are allowed
          = note: #[bench::my_id("with", "args")]
-                           or #[benches::my_id(args = [("with", "args"), ...)])]
+                           or #[benches::my_id(args = [("with", "args"), ...])]
 
  --> tests/ui/test_library_benchmark_invalid_attributes.rs:8:1
   |
@@ -24,7 +24,7 @@ error: Invalid attribute: 'inline'
 
          = help: Only the `bench` and the `benches` attribute are allowed
          = note: #[bench::my_id("with", "args")]
-                           or #[benches::my_id(args = [("with", "args"), ...)])]
+                           or #[benches::my_id(args = [("with", "args"), ...])]
 
   --> tests/ui/test_library_benchmark_invalid_attributes.rs:11:1
    |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
@@ -15,15 +15,15 @@ error: Failed parsing arguments: Expected 0 values per tuple
 6 | #[benches::multi(42)]
   |                  ^^
 
-error: Expected 1 arguments but found none
+error: Expected 1 argument(s) but found none
 
          = help: Try passing arguments either with #[bench::some_id(arg1, ...)]
                        or with #[bench::some_id(args = (arg1, ...))]
 
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:11:1
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:11:3
    |
 11 | #[bench::id()]
-   | ^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
 
 error: Expected 1 arguments but found 2
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:20:3

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
@@ -1,41 +1,49 @@
 error: Expected 0 arguments but found 1
- --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:5:3
+
+         = help: This argument is expected to have the same amount of parameters as the benchmark function
+
+ --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:5:13
   |
 5 | #[bench::id(42)]
-  |   ^^^^^^^^^^^^^
+  |             ^^
 
-error: Failed parsing arguments: Expected 0 values per tuple
+error: Expected 0 arguments but found 1
 
-         = help: If the benchmarking function has multiple parameters
-                           the arguments for #[benches::...] must be given as tuple
-         = note: #[benches::id((1, 2), (3, 4))] or #[benches::id(args = [(1, 2), (3, 4)])]
+         = help: This argument is expected to have the same amount of parameters as the benchmark function
 
  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:6:18
   |
 6 | #[benches::multi(42)]
   |                  ^^
 
-error: Expected 1 argument(s) but found none
+error: Expected 1 arguments but found 0
 
-         = help: Try passing arguments either with #[bench::some_id(arg1, ...)]
-                       or with #[bench::some_id(args = (arg1, ...))]
+         = help: This argument is expected to have the same amount of parameters as the benchmark function
 
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:11:3
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:10:1
    |
-11 | #[bench::id()]
-   |   ^^^^^^^^^^^
+10 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Expected 1 arguments but found 2
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:20:3
+
+         = help: This argument is expected to have the same amount of parameters as the benchmark function
+
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:20:13
    |
 20 | #[bench::id(42, 8)]
-   |   ^^^^^^^^^^^^^^^^
+   |             ^^
 
 error: Expected 1 arguments but found 2
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:24:3
+
+         = help: This argument is expected to have the same amount of parameters as the benchmark function
+
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:24:18
    |
 24 | #[benches::multi((42, 8))]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^
 
 error[E0603]: function `bench5` is private
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:52:13
@@ -95,10 +103,11 @@ help: provide the argument
 error[E0308]: mismatched types
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:29:13
    |
-28 | #[library_benchmark]
-   | -------------------- arguments to this function are incorrect
 29 | #[bench::id("hello")]
-   |             ^^^^^^^ expected `u8`, found `&str`
+   |             ^^^^^^^
+   |             |
+   |             expected `u8`, found `&str`
+   |             arguments to this function are incorrect
    |
 note: function defined here
   --> $RUST/core/src/hint.rs
@@ -109,10 +118,11 @@ note: function defined here
 error[E0308]: mismatched types
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:33:18
    |
-32 | #[library_benchmark]
-   | -------------------- arguments to this function are incorrect
 33 | #[benches::multi("hello")]
-   |                  ^^^^^^^ expected `u8`, found `&str`
+   |                  ^^^^^^^
+   |                  |
+   |                  expected `u8`, found `&str`
+   |                  arguments to this function are incorrect
    |
 note: function defined here
   --> $RUST/core/src/hint.rs

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
@@ -27,6 +27,17 @@ error: Expected 1 arguments but found 0
    |
    = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: Expected 1 arguments but found 0
+
+         = help: This argument is expected to have the same amount of parameters as the benchmark function
+
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:14:1
+   |
+14 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: Expected 1 arguments but found 2
 
          = help: This argument is expected to have the same amount of parameters as the benchmark function
@@ -80,25 +91,6 @@ note: the function `bench7` is defined here
    |
 48 | pub fn bench7() {}
    |     ^^^^^^^^^^^
-
-error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:16:4
-   |
-14 | #[library_benchmark]
-   | -------------------- an argument of type `i32` is missing
-15 | #[benches::multi(args = [])]
-16 | fn bench25(my: i32) {}
-   |    ^^^^^^^
-   |
-note: function defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:16:4
-   |
-16 | fn bench25(my: i32) {}
-   |    ^^^^^^^ -------
-help: provide the argument
-   |
-14 | bench25(/* i32 */)
-   |
 
 error[E0308]: mismatched types
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:29:13

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
@@ -1,6 +1,6 @@
 error: Invalid argument: invalid
 
-         = help: Valid arguments are: `args`, `config`, `teardown`
+         = help: Valid arguments are: `args`, `config`, `setup`, teardown`
 
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.rs:4:13
   |
@@ -9,7 +9,7 @@ error: Invalid argument: invalid
 
 error: Failed parsing `args`
 
-         = help: `args` must be an tuple/array which elements (expressions)
+         = help: `args` has to be a tuple/array which elements (expressions)
                                match the number of parameters of the benchmarking function
          = note: #[bench::id(args = (1, 2))] or
                                #[bench::id(args = [1, 2]])]

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
@@ -1,6 +1,6 @@
 error: Invalid argument: invalid
 
-         = help: Valid arguments are: args, config
+         = help: Valid arguments are: `args`, `config`, `teardown`
 
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.rs:4:13
   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.stderr
@@ -10,9 +10,9 @@ error: Invalid argument: invalid
 error: Failed parsing `args`
 
          = help: `args` must be an tuple/array which elements (expressions)
-                                   match the number of parameters of the benchmarking function
+                               match the number of parameters of the benchmarking function
          = note: #[bench::id(args = (1, 2))] or
-                                   #[bench::id(args = [1, 2]])]
+                               #[bench::id(args = [1, 2]])]
 
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_key_value.rs:8:20
   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
@@ -1,6 +1,6 @@
 error: Invalid argument: wrong
 
-         = help: Valid arguments are: args, config
+         = help: Valid arguments are: `args`, `config`, `teardown`
 
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:8:13
   |
@@ -15,7 +15,7 @@ error: unexpected end of input, expected an expression
 
 error: Invalid argument: wrong
 
-         = help: Valid arguments are: `args`, `config`, `setup`
+         = help: Valid arguments are: `args`, `config`, `setup`, `teardown`
 
   --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:16:18
    |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
@@ -22,16 +22,6 @@ error: Invalid argument: wrong
 16 | #[benches::wrong(wrong = LibraryBenchmarkConfig::default())]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Missing arguments for `benches`
-
-         = help: Either specify the `args` argument or use plain arguments
-         = note: `#[benches::id(args = [...])]` or `#[benches::id(1, 2, ...)]`
-
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:20:3
-   |
-20 | #[benches::missing_args(config = LibraryBenchmarkConfig::default())]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: unexpected end of input, expected an expression
   --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:23:1
    |
@@ -53,3 +43,22 @@ error[E0277]: the trait bound `InternalLibraryBenchmarkConfig: From<&str>` is no
             <InternalLibraryBenchmarkConfig as From<&mut LibraryBenchmarkConfig>>
             <InternalLibraryBenchmarkConfig as From<LibraryBenchmarkConfig>>
   = note: required for `&str` to implement `Into<InternalLibraryBenchmarkConfig>`
+
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:21:8
+   |
+19 | #[library_benchmark]
+   | -------------------- an argument of type `i32` is missing
+20 | #[benches::missing_args(config = LibraryBenchmarkConfig::default())]
+21 | pub fn bench40(_arg: i32) {}
+   |        ^^^^^^^
+   |
+note: function defined here
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:21:8
+   |
+21 | pub fn bench40(_arg: i32) {}
+   |        ^^^^^^^ ---------
+help: provide the argument
+   |
+19 | bench40(/* i32 */)
+   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
@@ -1,6 +1,6 @@
 error: Invalid argument: wrong
 
-         = help: Valid arguments are: `args`, `config`, `teardown`
+         = help: Valid arguments are: `args`, `config`, `setup`, teardown`
 
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:8:13
   |
@@ -23,12 +23,10 @@ error: Invalid argument: wrong
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected an expression
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:23:1
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:24:31
    |
-23 | #[library_benchmark]
-   | ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+24 | #[benches::missing_expression(args = [], config = )]
+   |                               ^^^^
 
 error[E0277]: the trait bound `InternalLibraryBenchmarkConfig: From<&str>` is not satisfied
  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:4:22

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.stderr
@@ -22,6 +22,17 @@ error: Invalid argument: wrong
 16 | #[benches::wrong(wrong = LibraryBenchmarkConfig::default())]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: Expected 1 arguments but found 0
+
+         = help: This argument is expected to have the same amount of parameters as the benchmark function
+
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:19:1
+   |
+19 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: unexpected end of input, expected an expression
   --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:24:31
    |
@@ -41,22 +52,3 @@ error[E0277]: the trait bound `InternalLibraryBenchmarkConfig: From<&str>` is no
             <InternalLibraryBenchmarkConfig as From<&mut LibraryBenchmarkConfig>>
             <InternalLibraryBenchmarkConfig as From<LibraryBenchmarkConfig>>
   = note: required for `&str` to implement `Into<InternalLibraryBenchmarkConfig>`
-
-error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:21:8
-   |
-19 | #[library_benchmark]
-   | -------------------- an argument of type `i32` is missing
-20 | #[benches::missing_args(config = LibraryBenchmarkConfig::default())]
-21 | pub fn bench40(_arg: i32) {}
-   |        ^^^^^^^
-   |
-note: function defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments_when_config.rs:21:8
-   |
-21 | pub fn bench40(_arg: i32) {}
-   |        ^^^^^^^ ---------
-help: provide the argument
-   |
-19 | bench40(/* i32 */)
-   |

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs
@@ -1,0 +1,89 @@
+use iai_callgrind::library_benchmark;
+
+fn setup_no_args() -> u64 {
+    42
+}
+
+fn setup_u64_to_string(value: u64) -> String {
+    format!("{value}")
+}
+
+fn setup_str_to_string(value: &str) -> String {
+    value.to_owned()
+}
+
+fn teardown_unit(_: ()) {}
+
+fn teardown_u64(_: u64) {}
+
+// setup with wrong input type
+#[library_benchmark]
+#[bench::id(args = ("wrong type"), setup = setup_u64_to_string)]
+fn bench10(a: String) {
+    _ = a;
+}
+
+// setup with wrong output type
+#[library_benchmark]
+#[bench::id(args = (10), setup = setup_u64_to_string)]
+fn bench11(a: u64) {
+    _ = a;
+}
+
+// global correct setup is overwritten with wrong setup
+#[library_benchmark(setup = setup_str_to_string)]
+#[bench::id(args = ("wrong type"), setup = setup_u64_to_string)]
+fn bench12(a: String) {
+    _ = a;
+}
+
+// teardown has wrong input type
+#[library_benchmark]
+#[bench::id(teardown = teardown_unit)]
+fn bench20() -> u64 {
+    42
+}
+
+// global correct teardown is overwritten with wrong teardown
+#[library_benchmark(teardown = teardown_u64)]
+#[bench::id(teardown = teardown_unit)]
+fn bench21() -> u64 {
+    42
+}
+
+// setup with wrong input type
+#[library_benchmark]
+#[benches::id(args = ["wrong type"], setup = setup_u64_to_string)]
+fn bench30(a: String) {
+    _ = a;
+}
+
+// setup with wrong output type
+#[library_benchmark]
+#[benches::id(args = [10], setup = setup_u64_to_string)]
+fn bench31(a: u64) {
+    _ = a;
+}
+
+// global correct setup is overwritten with wrong setup
+#[library_benchmark(setup = setup_str_to_string)]
+#[benches::id(args = ["wrong type"], setup = setup_u64_to_string)]
+fn bench32(a: String) {
+    _ = a;
+}
+
+// teardown has wrong input type
+#[library_benchmark]
+#[benches::id(teardown = teardown_unit)]
+fn bench40() -> u64 {
+    42
+}
+
+// global correct teardown is overwritten with wrong teardown
+// #[library_benchmark(teardown = teardown_u64)]
+// #[benches::id(teardown = teardown_unit)]
+// fn bench41() -> u64 {
+//     42
+// }
+
+fn main() {}

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.stderr
@@ -1,0 +1,137 @@
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:21:21
+   |
+21 | #[bench::id(args = ("wrong type"), setup = setup_u64_to_string)]
+   |                    -^^^^^^^^^^^^-
+   |                    ||
+   |                    |expected `u64`, found `&str`
+   |                    arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:28:34
+   |
+28 | #[bench::id(args = (10), setup = setup_u64_to_string)]
+   |                                  ^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  expected `u64`, found struct `String`
+   |                                  arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:35:21
+   |
+35 | #[bench::id(args = ("wrong type"), setup = setup_u64_to_string)]
+   |                    -^^^^^^^^^^^^-
+   |                    ||
+   |                    |expected `u64`, found `&str`
+   |                    arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:41:1
+   |
+41 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   | |
+   | expected `()`, found `u64`
+   | arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:48:1
+   |
+48 | #[library_benchmark(teardown = teardown_u64)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | expected `()`, found `u64`
+   | arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:56:23
+   |
+56 | #[benches::id(args = ["wrong type"], setup = setup_u64_to_string)]
+   |                       ^^^^^^^^^^^^
+   |                       |
+   |                       expected `u64`, found `&str`
+   |                       arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:63:36
+   |
+63 | #[benches::id(args = [10], setup = setup_u64_to_string)]
+   |                                    ^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    expected `u64`, found struct `String`
+   |                                    arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:70:23
+   |
+70 | #[benches::id(args = ["wrong type"], setup = setup_u64_to_string)]
+   |                       ^^^^^^^^^^^^
+   |                       |
+   |                       expected `u64`, found `&str`
+   |                       arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_bench_setup_and_teardown.rs:76:1
+   |
+76 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   | |
+   | expected `()`, found `u64`
+   | arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs
@@ -1,0 +1,39 @@
+use iai_callgrind::library_benchmark;
+
+fn setup_no_args() -> u64 {
+    42
+}
+
+fn setup_string(value: u64) -> String {
+    format!("{value}")
+}
+
+fn teardown_unit(_: ()) {}
+
+#[library_benchmark(setup = does_not_exist)]
+fn bench10(value: u64) {
+    _ = value;
+}
+
+#[library_benchmark(teardown = does_not_exist)]
+fn bench11() {}
+
+// setup has missing argument
+#[library_benchmark(setup = setup_no_args)]
+fn bench20(value: u64) {
+    _ = value;
+}
+
+// setup has wrong output type
+#[library_benchmark(setup = setup_string)]
+fn bench21(value: u64) {
+    _ = value;
+}
+
+// teardown has wrong argument type
+#[library_benchmark(teardown = teardown_unit)]
+fn bench40() -> u64 {
+    42
+}
+
+fn main() {}

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_setup_and_teardown.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_setup_and_teardown.stderr
@@ -1,0 +1,58 @@
+error[E0425]: cannot find function `does_not_exist` in this scope
+  --> tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs:13:29
+   |
+13 | #[library_benchmark(setup = does_not_exist)]
+   |                             ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `does_not_exist` in this scope
+  --> tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs:18:32
+   |
+18 | #[library_benchmark(teardown = does_not_exist)]
+   |                                ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs:28:29
+   |
+28 | #[library_benchmark(setup = setup_string)]
+   |                             ^^^^^^^^^^^^ an argument of type `u64` is missing
+   |
+note: function defined here
+  --> tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs:7:4
+   |
+7  | fn setup_string(value: u64) -> String {
+   |    ^^^^^^^^^^^^ ----------
+help: provide the argument
+   |
+28 | #[library_benchmark(setup = setup_string(/* u64 */))]
+   |                                         +++++++++++
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs:28:29
+   |
+28 | #[library_benchmark(setup = setup_string)]
+   |                             ^^^^^^^^^^^^
+   |                             |
+   |                             expected `u64`, found struct `String`
+   |                             arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/test_library_benchmark_invalid_setup_and_teardown.rs:34:1
+   |
+34 | #[library_benchmark(teardown = teardown_unit)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | expected `()`, found `u64`
+   | arguments to this function are incorrect
+   |
+note: function defined here
+  --> $RUST/core/src/hint.rs
+   |
+   | pub const fn black_box<T>(dummy: T) -> T {
+   |              ^^^^^^^^^
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/iai-callgrind/tests/ui/test_library_benchmark_valid_setup_and_teardown.rs
+++ b/iai-callgrind/tests/ui/test_library_benchmark_valid_setup_and_teardown.rs
@@ -1,0 +1,45 @@
+use iai_callgrind::{library_benchmark, LibraryBenchmarkConfig};
+
+fn setup_no_args() -> u64 {
+    42
+}
+
+fn teardown_unit(_: ()) {}
+
+// no parameters
+#[library_benchmark]
+fn bench10() {}
+
+// no parameters but useless parentheses
+#[library_benchmark()]
+fn bench11() {}
+
+// just teardown
+#[library_benchmark(teardown = teardown_unit)]
+fn bench12() {}
+
+// just setup
+#[library_benchmark(setup = setup_no_args)]
+fn bench13(value: u64) {
+    _ = value;
+}
+
+// just config
+#[library_benchmark(config = LibraryBenchmarkConfig::default())]
+fn bench14() {}
+
+
+// with all valid parameters
+#[library_benchmark(config = LibraryBenchmarkConfig::default(), setup = setup_no_args, teardown = teardown_unit)]
+fn bench20(value: u64) {
+    _ = value;
+}
+
+// Mix the order of the parameters
+#[library_benchmark(teardown = teardown_unit, setup = setup_no_args, config = LibraryBenchmarkConfig::default())]
+fn bench21(value: u64) {
+    _ = value;
+}
+
+
+fn main() {}


### PR DESCRIPTION
This pr adds the possiblity to specify a teardown function in `#[bench]` and `#[benches]`

```rust
fn my_teardown(value: u64) {
    println!("{value}");
}

#[library_benchmark]
#[bench::some_id(args = (), teardown = my_teardown)]
fn some_bench() -> u64 {
     my_lib::some_func()
}
```

Here, `my_teardown` is called with the result of `my_lib::some_func()`. This works the same way for the `#[benches]` attribute.

For completeness and consistency the `#[bench]` attribute now also allows to specify a `setup` parameter. This wasn't strictly necessary because the args parameter takes expressions. Before this change it was possible to specify the setup function like so

```rust
fn my_setup(a: u64, b: u64) -> u64 {
    a + b
}

#[library_benchmark]
#[bench::some_id(args = my_setup(2, 3))]
fn some_bench(value: u64) -> u64 {
     my_lib::some_func(value)
}
```

Now it's also possible to do it like that

```rust
fn my_setup(a: u64, b: u64) -> u64 {
    a + b
}

#[library_benchmark]
#[bench::some_id(args = (2, 3), setup = my_setup)]
fn some_bench(value: u64) -> u64 {
     my_lib::some_func(value)
}
```

Also new is the possibility to specify a global setup and teardown function in `#[library_benchmark]` which are applied to all following `#[bench]` and `#[benches]`

```rust
fn my_setup(a: u64, b: u64) -> u64 {
    a + b
}

fn my_teardown(value: u64) {
    println!("{value}");
}

#[library_benchmark(setup = my_setup, teardown = my_teardown]
#[bench::first(2, 3)]
#[benches::multiple((3, 4), (4, 5))]
fn some_bench(value: u64) -> u64 {
     my_lib::some_func(value)
}
```

It's possible to overwrite the global setup or teardown function by specifying a setup or teardown function in the `#[bench]` or `#[benches]` attribute.

I also felt like `iai-callgrind-macros::lib` needed a refactor in order to simplify the implemention of the new features and removed code duplication, deeply nested for loops, if statements etc.

On the way, this pr solved an error:

* If the setup parameter was specified before the args parameter and the number of arguments of the args parameter didn't match with the number of arguments of benchmark function then there was an error although the setup function returned the correct number of arguments.

Related #171 