### PR TITLE
fix(#198): Support generic benchmark functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_regex",
  "serde_yaml",
  "serial_test",
  "shlex",
@@ -1441,6 +1442,16 @@ checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ sanitize-filename = { version = "0.5" }
 schemars = { version = "0.8.16", features = ["indexmap2"] }
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = { version = "1.0.79" }
+serde_regex = { version = "1.1" }
 serde_yaml = { version = "0.9" }
 serial_test = { version = "3" }
 shlex = { version = "1.3" }

--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -125,4 +125,12 @@ name = "test_lib_bench_nocapture"
 
 [[bench]]
 harness = false
+name = "test_lib_bench_compiler_optimization"
+
+[[bench]]
+harness = false
+name = "test_lib_bench_generics"
+
+[[bench]]
+harness = false
 name = "test_bench"

--- a/benchmark-tests/benches/test_lib_bench_compiler_optimization.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench_compiler_optimization.conf.yml
@@ -1,0 +1,5 @@
+groups:
+  - runs:
+      - args: []
+        expected:
+          files: test_lib_bench_compiler_optimization.expected.1.yml

--- a/benchmark-tests/benches/test_lib_bench_compiler_optimization.expected.1.yml
+++ b/benchmark-tests/benches/test_lib_bench_compiler_optimization.expected.1.yml
@@ -1,0 +1,31 @@
+data:
+  - group: my_group
+    function: bench
+    expected:
+      files:
+        - callgrind.bench.log
+        - callgrind.bench.out
+        - summary.json
+  - group: my_group
+    function: bench_with_longer_name
+    expected:
+      files:
+        - callgrind.bench_with_longer_name.log
+        - callgrind.bench_with_longer_name.out
+        - summary.json
+  - group: my_group
+    function: bench_with_bench
+    id: first
+    expected:
+      files:
+        - callgrind.bench_with_bench.first.log
+        - callgrind.bench_with_bench.first.out
+        - summary.json
+  - group: my_group
+    function: bench_with_bench_longer_name
+    id: first
+    expected:
+      files:
+        - callgrind.bench_with_bench_longer_name.first.log
+        - callgrind.bench_with_bench_longer_name.first.out
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench_compiler_optimization.rs
+++ b/benchmark-tests/benches/test_lib_bench_compiler_optimization.rs
@@ -1,0 +1,32 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+
+#[library_benchmark]
+fn bench() -> Vec<u64> {
+    vec![1]
+}
+
+// Since this benchmark function is equal to the `bench` function above, the compiler will optimize
+// this one away (it has the longer name). This means for us we can't match for
+// `bench_with_longer_name` in the callgrind output files and need a little bit of trickery.
+#[library_benchmark]
+fn bench_with_longer_name() -> Vec<u64> {
+    vec![1]
+}
+
+// The same here but now we annotate the function with a `#[bench]` to take another path in the
+// source code of `iai-callgrind-macros`
+#[library_benchmark]
+#[bench::first(1)]
+fn bench_with_bench(value: u64) -> Vec<u64> {
+    vec![value]
+}
+
+#[library_benchmark]
+#[bench::first(1)]
+fn bench_with_bench_longer_name(value: u64) -> Vec<u64> {
+    vec![value]
+}
+
+library_benchmark_group!(name = my_group; benchmarks = bench, bench_with_longer_name, bench_with_bench, bench_with_bench_longer_name);
+
+main!(library_benchmark_groups = my_group);

--- a/benchmark-tests/benches/test_lib_bench_generics.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench_generics.conf.yml
@@ -1,0 +1,5 @@
+groups:
+  - runs:
+      - args: []
+        expected:
+          files: test_lib_bench_generics.expected.1.yml

--- a/benchmark-tests/benches/test_lib_bench_generics.expected.1.yml
+++ b/benchmark-tests/benches/test_lib_bench_generics.expected.1.yml
@@ -1,0 +1,17 @@
+data:
+  - group: bench_format_group
+    function: bench_format
+    id: a
+    expected:
+      files:
+        - callgrind.bench_format.a.log
+        - callgrind.bench_format.a.out
+        - summary.json
+  - group: bench_format_group
+    function: bench_format
+    id: b
+    expected:
+      files:
+        - callgrind.bench_format.b.log
+        - callgrind.bench_format.b.out
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench_generics.rs
+++ b/benchmark-tests/benches/test_lib_bench_generics.rs
@@ -1,0 +1,37 @@
+/// See issue https://github.com/iai-callgrind/iai-callgrind/issues/198
+/// Generic bench arguments cause compilation failure
+///
+/// After the fix the benchmark should now compile
+use iai_callgrind::{black_box, library_benchmark, library_benchmark_group, main};
+
+#[derive(Debug)]
+struct A;
+
+fn input_a() -> A {
+    A
+}
+
+#[derive(Debug)]
+struct B;
+
+fn input_b() -> B {
+    B
+}
+
+fn run_format(input: impl std::fmt::Debug) -> usize {
+    format!("{:?}", input).len()
+}
+
+#[library_benchmark]
+#[bench::a(input_a())]
+#[bench::b(input_b())]
+fn bench_format<I: std::fmt::Debug>(input: I) -> usize {
+    black_box(run_format(input))
+}
+
+library_benchmark_group!(
+    name = bench_format_group;
+    benchmarks = bench_format
+);
+
+main!(library_benchmark_groups = bench_format_group);

--- a/benchmark-tests/benches/test_lib_bench_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_lib_bench_setup_and_teardown.rs
@@ -97,7 +97,7 @@ library_benchmark_group!(
         bench_only_setup,
         bench_only_teardown,
         benches_only_setup,
-        bench_only_teardown,
+        benches_only_teardown,
         benches_global_setup_and_teardown
 );
 

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -116,6 +116,7 @@ struct RunConfig {
     args: Vec<String>,
     #[serde(default)]
     template_data: HashMap<String, minijinja::Value>,
+    #[serde(default)]
     expected: Option<ExpectedConfig>,
     #[serde(default)]
     runs_on: Option<String>,

--- a/iai-callgrind-runner/Cargo.toml
+++ b/iai-callgrind-runner/Cargo.toml
@@ -35,6 +35,7 @@ runner = [
   "dep:sanitize-filename",
   "dep:serde",
   "dep:serde_json",
+  "dep:serde_regex",
   "dep:shlex",
   "dep:tempfile",
   "dep:version-compare",
@@ -65,6 +66,7 @@ sanitize-filename = { workspace = true, optional = true }
 schemars = { workspace = true, features = ["indexmap1"], optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
+serde_regex = { workspace = true, optional = true }
 shlex = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 version-compare = { workspace = true, optional = true }

--- a/iai-callgrind-runner/src/runner/bin_bench.rs
+++ b/iai-callgrind-runner/src/runner/bin_bench.rs
@@ -494,7 +494,10 @@ impl Benchmarkable for BinBench {
     }
 
     fn sentinel(&self, _config: &Config) -> Option<Sentinel> {
-        self.run_options.entry_point.as_ref().map(Sentinel::new)
+        self.run_options
+            .entry_point
+            .as_ref()
+            .and_then(|e| Sentinel::from_glob(e).ok())
     }
 }
 

--- a/iai-callgrind-runner/src/runner/callgrind/parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/parser.rs
@@ -5,6 +5,7 @@ use log::{trace, warn};
 use serde::{Deserialize, Serialize};
 
 use super::model::{Costs, Positions};
+use crate::runner::DEFAULT_TOGGLE;
 
 #[derive(Debug, Default)]
 pub struct CallgrindProperties {
@@ -50,7 +51,7 @@ impl Sentinel {
     }
 
     pub fn matches(&self, string: &str) -> bool {
-        string.starts_with(self.0.as_str())
+        string.contains(self.0.as_str())
     }
 }
 
@@ -60,9 +61,21 @@ impl AsRef<Sentinel> for Sentinel {
     }
 }
 
+impl Default for Sentinel {
+    fn default() -> Self {
+        Self::new(DEFAULT_TOGGLE.to_owned())
+    }
+}
+
 impl Display for Sentinel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+impl From<Sentinel> for String {
+    fn from(value: Sentinel) -> Self {
+        value.0.clone()
     }
 }
 

--- a/iai-callgrind-runner/src/runner/callgrind/parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/parser.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use log::{trace, warn};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use super::model::{Costs, Positions};
@@ -13,22 +14,56 @@ pub struct CallgrindProperties {
     pub positions_prototype: Positions,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Sentinel(String);
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sentinel(#[serde(with = "serde_regex")] Regex);
 
 impl Sentinel {
-    pub fn new<T>(value: T) -> Self
+    /// Create a new Sentinel
+    ///
+    /// A Sentinel is converted to a regex internally which matches from line start to line end.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use iai_callgrind_runner::runner::callgrind::parser::Sentinel;
+    ///
+    /// let sentinel = Sentinel::new("main").unwrap();
+    /// assert_eq!(sentinel.to_string(), String::from("^main$"));
+    /// ```
+    pub fn new<T>(value: T) -> Result<Self>
     where
-        T: Into<String>,
+        T: AsRef<str>,
     {
-        Self(value.into())
+        Regex::new(&format!("^{}$", value.as_ref()))
+            .map(Self)
+            .with_context(|| "Invalid sentinel")
+    }
+
+    /// Create a new Sentinel from a glob pattern
+    ///
+    /// The `*` are replaced with `.*` because we need the glob as regex. Additionally, the glob
+    /// matches from the start to end of the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use iai_callgrind_runner::runner::callgrind::parser::Sentinel;
+    ///
+    /// let sentinel = Sentinel::from_glob("*::main").unwrap();
+    /// assert_eq!(sentinel.to_string(), String::from("^.*::main$"));
+    /// ```
+    pub fn from_glob<T>(glob: T) -> Result<Self>
+    where
+        T: AsRef<str>,
+    {
+        let regex = glob.as_ref().replace('*', ".*");
+        Self::new(regex)
     }
 
     pub fn from_path(module: &str, function: &str) -> Self {
-        Self(format!("{module}::{function}"))
+        Self::new(format!("{module}::{function}")).expect("Regex should compile")
     }
 
-    #[allow(unused)]
     pub fn from_segments<I, T>(segments: T) -> Self
     where
         I: AsRef<str>,
@@ -43,15 +78,11 @@ impl Sentinel {
         } else {
             String::new()
         };
-        Self(joined)
+        Self::new(joined).expect("Regex should compile")
     }
 
-    pub fn to_fn(&self) -> String {
-        format!("fn={}", self.0)
-    }
-
-    pub fn matches(&self, string: &str) -> bool {
-        string.contains(self.0.as_str())
+    pub fn matches(&self, haystack: &str) -> bool {
+        self.0.is_match(haystack)
     }
 }
 
@@ -63,19 +94,27 @@ impl AsRef<Sentinel> for Sentinel {
 
 impl Default for Sentinel {
     fn default() -> Self {
-        Self::new(DEFAULT_TOGGLE.to_owned())
+        Self::from_glob(DEFAULT_TOGGLE).expect("Default toggle should compile as regex")
     }
 }
 
 impl Display for Sentinel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+        f.write_str(self.0.as_str())
     }
 }
 
+impl Eq for Sentinel {}
+
 impl From<Sentinel> for String {
     fn from(value: Sentinel) -> Self {
-        value.0.clone()
+        value.0.as_str().to_owned()
+    }
+}
+
+impl PartialEq for Sentinel {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
     }
 }
 

--- a/iai-callgrind-runner/src/runner/lib_bench.rs
+++ b/iai-callgrind-runner/src/runner/lib_bench.rs
@@ -258,7 +258,7 @@ impl Groups {
                         args: library_benchmark_bench.args,
                         options: RunOptions {
                             env_clear: config.env_clear.unwrap_or(true),
-                            entry_point: Some(format!("*{DEFAULT_TOGGLE}*")),
+                            entry_point: Some(DEFAULT_TOGGLE.to_owned()),
                             envs,
                             ..Default::default()
                         },

--- a/iai-callgrind-runner/src/runner/lib_bench.rs
+++ b/iai-callgrind-runner/src/runner/lib_bench.rs
@@ -24,7 +24,7 @@ use super::summary::{
 use super::tool::{
     Parser, RunOptions, ToolConfigs, ToolOutputPath, ToolOutputPathKind, ValgrindTool,
 };
-use super::{Config, Error};
+use super::{Config, Error, DEFAULT_TOGGLE};
 use crate::api::{self, LibraryBenchmark};
 
 /// Implements [`Benchmark`] to run a [`LibBench`] and compare against a earlier [`BenchmarkKind`]
@@ -127,7 +127,7 @@ impl Benchmark for BaselineBenchmark {
         let callgrind_command = CallgrindCommand::new(&config.meta);
         let bench_args = lib_bench.bench_args(group);
 
-        let sentinel = Sentinel::new("iai_callgrind::bench::");
+        let sentinel = Sentinel::default();
         let out_path = self.output_path(lib_bench, config, group);
         out_path.init()?;
         out_path.shift()?;
@@ -258,7 +258,7 @@ impl Groups {
                         args: library_benchmark_bench.args,
                         options: RunOptions {
                             env_clear: config.env_clear.unwrap_or(true),
-                            entry_point: Some("iai_callgrind::bench::*".to_owned()),
+                            entry_point: Some(format!("*{DEFAULT_TOGGLE}*")),
                             envs,
                             ..Default::default()
                         },
@@ -443,7 +443,7 @@ impl Benchmark for LoadBaselineBenchmark {
         group: &Group,
     ) -> Result<BenchmarkSummary> {
         let bench_args = lib_bench.bench_args(group);
-        let sentinel = Sentinel::new("iai_callgrind::bench::");
+        let sentinel = Sentinel::default();
         let out_path = self.output_path(lib_bench, config, group);
         let old_path = out_path.to_base_path();
         let log_path = out_path.to_log_output();
@@ -570,7 +570,7 @@ impl Benchmark for SaveBaselineBenchmark {
         let bench_args = lib_bench.bench_args(group);
         let baselines = self.baselines();
 
-        let sentinel = Sentinel::new("iai_callgrind::bench::");
+        let sentinel = Sentinel::default();
         let out_path = self.output_path(lib_bench, config, group);
         out_path.init()?;
 

--- a/iai-callgrind-runner/src/runner/mod.rs
+++ b/iai-callgrind-runner/src/runner/mod.rs
@@ -29,7 +29,7 @@ pub mod envs {
     pub const CARGO_TERM_COLOR: &str = "CARGO_TERM_COLOR";
 }
 
-pub const DEFAULT_TOGGLE: &str = "::__iai_callgrind_wrapper_mod::";
+pub const DEFAULT_TOGGLE: &str = "*::__iai_callgrind_wrapper_mod::*";
 
 #[derive(Debug)]
 pub struct Config {

--- a/iai-callgrind-runner/src/runner/mod.rs
+++ b/iai-callgrind-runner/src/runner/mod.rs
@@ -29,6 +29,8 @@ pub mod envs {
     pub const CARGO_TERM_COLOR: &str = "CARGO_TERM_COLOR";
 }
 
+pub const DEFAULT_TOGGLE: &str = "::__iai_callgrind_wrapper_mod::";
+
 #[derive(Debug)]
 pub struct Config {
     package_dir: PathBuf,

--- a/iai-callgrind-runner/tests/test_callgrind/test_flamegraph_parser.rs
+++ b/iai-callgrind-runner/tests/test_callgrind/test_flamegraph_parser.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use iai_callgrind_runner::api::EventKind;
 use iai_callgrind_runner::runner::callgrind::flamegraph_parser::FlamegraphParser;
 use iai_callgrind_runner::runner::callgrind::parser::Sentinel;
@@ -9,7 +10,8 @@ use crate::common::{get_project_root, Fixtures};
 #[rstest]
 #[case::when_entry_point("when_entry_point", Some(Sentinel::new("benchmark_tests_exit::main")))]
 #[case::no_entry_point("no_entry_point", None)]
-fn test_flamegraph_parser(#[case] name: &str, #[case] sentinel: Option<Sentinel>) {
+fn test_flamegraph_parser(#[case] name: &str, #[case] sentinel: Option<Result<Sentinel>>) {
+    let sentinel = sentinel.map(|s| s.unwrap());
     let output = Fixtures::get_tool_output_path(
         "callgrind.out",
         ValgrindTool::Callgrind,

--- a/iai-callgrind-runner/tests/test_callgrind/test_sentinel_parser.rs
+++ b/iai-callgrind-runner/tests/test_callgrind/test_sentinel_parser.rs
@@ -36,7 +36,7 @@ fn test_sentinel_parser(#[case] sentinel: &str, #[case] costs: [u64; 9]) {
         "no_entry_point",
     );
 
-    let parser = SentinelParser::new(&Sentinel::new(sentinel));
+    let parser = SentinelParser::new(&Sentinel::new(sentinel).unwrap());
     let actual_costs = parser.parse(&callgrind_output).unwrap();
 
     assert_eq!(actual_costs, expected_costs);
@@ -50,7 +50,7 @@ fn test_sentinel_parser_when_not_found_then_error() {
         ToolOutputPathKind::Out,
         "no_entry_point",
     );
-    let sentinel = Sentinel::new("doesnotexist");
+    let sentinel = Sentinel::new("doesnotexist").unwrap();
 
     let result = SentinelParser::new(&sentinel).parse(&callgrind_output);
 
@@ -58,7 +58,7 @@ fn test_sentinel_parser_when_not_found_then_error() {
         &callgrind_output.to_path(),
         result,
         &format!(
-            "Sentinel 'doesnotexist' not found.{}",
+            "Sentinel '^doesnotexist$' not found.{}",
             ERROR_MESSAGE_DEBUG_SYMBOLS
         ),
     )

--- a/iai-callgrind/src/bin_bench.rs
+++ b/iai-callgrind/src/bin_bench.rs
@@ -525,6 +525,20 @@ impl BinaryBenchmarkConfig {
     /// any function) and stop counting when leaving the main function of the executable. The
     /// following example will show how to do that.
     ///
+    /// # Glob Patterns
+    ///
+    /// Glob patterns are allowed in the same way as callgrind's --toggle-collect option allows glob
+    /// patterns. Note the pattern matches from start to end of the path. For example `*::main`
+    /// matches
+    ///
+    /// * `my_exe::main`
+    /// * `other::main`
+    ///
+    /// but not:
+    ///
+    /// * `main`
+    /// * `other::main::sub`
+    ///
     /// # Examples
     ///
     /// The `entry_point` could look like `my_exe::main` for a binary with the name `my-exe` (Note

--- a/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
+++ b/iai-callgrind/tests/ui/test_library_benchmark_invalid_bench_arguments.stderr
@@ -56,41 +56,98 @@ error: Expected 1 arguments but found 2
 24 | #[benches::multi((42, 8))]
    |                  ^^^^^^^
 
-error[E0603]: function `bench5` is private
+error[E0423]: expected function, found module `bench5::bench5`
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:52:5
+   |
+52 |     bench5::bench5();
+   |     ^^^^^^^^^^^^^^ not a function
+   |
+note: function `crate::bench5::__iai_callgrind_wrapper_mod::bench5` exists but is inaccessible
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:37:1
+   |
+37 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^ not accessible
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected function, found module `bench6::bench6`
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:54:5
+   |
+54 |     bench6::bench6();
+   |     ^^^^^^^^^^^^^^ not a function
+   |
+note: function `crate::bench6::__iai_callgrind_wrapper_mod::bench6` exists but is inaccessible
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:43:1
+   |
+43 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^ not accessible
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0423]: expected function, found module `bench7::bench7`
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:56:5
+   |
+56 |     bench7::bench7();
+   |     ^^^^^^^^^^^^^^ not a function
+   |
+note: function `crate::bench7::__iai_callgrind_wrapper_mod::bench7` exists but is inaccessible
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:46:1
+   |
+46 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^ not accessible
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0603]: module import `bench5` is private
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:52:13
    |
 52 |     bench5::bench5();
-   |             ^^^^^^ private function
+   |             ^^^^^^ private module import
    |
-note: the function `bench5` is defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:39:1
+note: the module import `bench5` is defined here...
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:37:1
    |
-39 | fn bench5(my: u8) -> String {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+37 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+note: ...and refers to the module `bench5` which is defined here
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:37:1
+   |
+37 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0603]: function `bench6` is private
+error[E0603]: module import `bench6` is private
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:54:13
    |
 54 |     bench6::bench6();
-   |             ^^^^^^ private function
+   |             ^^^^^^ private module import
    |
-note: the function `bench6` is defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:44:5
+note: the module import `bench6` is defined here...
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:43:1
    |
-44 | pub fn bench6() {}
-   |     ^^^^^^^^^^^
+43 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+note: ...and refers to the module `bench6` which is defined here
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:43:1
+   |
+43 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0603]: function `bench7` is private
+error[E0603]: module import `bench7` is private
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:56:13
    |
 56 |     bench7::bench7();
-   |             ^^^^^^ private function
+   |             ^^^^^^ private module import
    |
-note: the function `bench7` is defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:48:5
+note: the module import `bench7` is defined here...
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:46:1
    |
-48 | pub fn bench7() {}
-   |     ^^^^^^^^^^^
+46 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+note: ...and refers to the module `bench7` which is defined here
+  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:46:1
+   |
+46 | #[library_benchmark]
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `library_benchmark` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:29:13
@@ -131,19 +188,3 @@ error[E0308]: mismatched types
    |     ^^- help: try using a conversion method: `.to_string()`
    |     |
    |     expected struct `String`, found `u8`
-
-error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:52:5
-   |
-52 |     bench5::bench5();
-   |     ^^^^^^^^^^^^^^-- an argument of type `u8` is missing
-   |
-note: function defined here
-  --> tests/ui/test_library_benchmark_invalid_bench_arguments.rs:39:4
-   |
-39 | fn bench5(my: u8) -> String {
-   |    ^^^^^^ ------
-help: provide the argument
-   |
-52 |     bench5::bench5(/* u8 */);
-   |                   ~~~~~~~~~~


### PR DESCRIPTION
This pr adds support for generic benchmark functions. 

Benchmark functions were exported under a different name `iai_callgrind::bench::FUNCTION_NAME` with `FUNCTION_NAME` being the original function name:

In short:

```rust
#[library_benchmark]
fn my_bench() -> u64 { 42 }
```

was roughly converted to

```rust
mod my_bench {
    # ...
    #[inline(never)]
    #[export_name = "iai_callgrind::bench::my_bench"]
    fn my_bench() -> u64 { 42 }
    # ...
}
```

The main reason for having the different export name is to have a constant string we can match for in the callgrind output files. So, a function starting with `iai_callgrind::bench::` was the benchmark function. The compiler optimizes functions which are semantically equivalent

```rust
#[library_benchmark]
fn my_bench() -> u64 { 42 }

#[library_benchmark]
fn my_other_bench_with_a_longer_function_name() -> u64 { 42 }
```

into a single function, taking the function with the shorter name. Having a constant string which is unique for our benchmark functions, we can match for the unique string and not the exact function name (which might have changed by the compiler as shown above). To support generic benchmark functions we can't use the `export_name` annotation. Maybe, the compiler should issue a warning for generic functions annotated with `export_name`. However, the benchmark function is now placed into a wrapper module having the name `__iai_callgrind_wrapper_mod`. We now match for this module name instead of a function starting with `iai_callgrind::bench`.

Due to some closely related internal changes and as a side effect, the `BinaryBenchmarkConfig::entry_point` function now allows glob patterns instead of just exact function names.

Closes #198 