### PR TITLE
iai-callgrind-runner: Provide better error message if the argument parsing of the runner itself fails

### DIFF
--- a/iai-callgrind-runner/src/error.rs
+++ b/iai-callgrind-runner/src/error.rs
@@ -11,6 +11,7 @@ use crate::util::write_all_to_stderr;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
+    InitError(String),
     VersionMismatch(version_compare::Cmp, String, String),
     LaunchError(PathBuf, String),
     ProcessError((String, Option<Output>, ExitStatus, Option<ToolOutputPath>)),
@@ -25,6 +26,18 @@ impl std::error::Error for Error {}
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::InitError(message) => {
+                let runner_version = env!("CARGO_PKG_VERSION").to_owned();
+                write!(
+                    f,
+                    "Failed to initialize iai-callgrind-runner: {message}\n\nDetected version of \
+                     iai-callgrind-runner is {runner_version}. This error can be caused by a \
+                     version mismatch between iai-callgrind and iai-callgrind-runner. If you \
+                     updated the library (iai-callgrind) in your Cargo.toml file, the binary \
+                     (iai-callgrind-runner) needs to be updated to the same version and vice \
+                     versa."
+                )
+            }
             Self::VersionMismatch(cmp, runner_version, library_version) => match cmp {
                 Cmp::Lt => write!(
                     f,

--- a/iai-callgrind-runner/tests/test_runner_binary/mod.rs
+++ b/iai-callgrind-runner/tests/test_runner_binary/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod test_version;

--- a/iai-callgrind-runner/tests/test_runner_binary/test_version.rs
+++ b/iai-callgrind-runner/tests/test_runner_binary/test_version.rs
@@ -1,0 +1,90 @@
+use rstest::rstest;
+
+use crate::common;
+
+#[rstest]
+#[case::major("major")]
+#[case::minor("minor")]
+#[case::patch("patch")]
+fn test_library_version_newer_than_runner_version(#[case] part: &str) {
+    let runner_version = common::get_runner_version();
+    let library_version = {
+        let mut library_version = runner_version.clone();
+        library_version.increment(part);
+        library_version
+    };
+
+    let expected_stderr = format!(
+        "iai_callgrind_runner: Error: iai-callgrind-runner ({runner_version}) is older than \
+         iai-callgrind ({library_version}). Please update iai-callgrind-runner by calling 'cargo \
+         install --version {library_version} iai-callgrind-runner'\n"
+    );
+
+    common::Runner::new()
+        .args(&[&library_version.to_string()])
+        .run()
+        .assert_stderr_bytes(expected_stderr.as_bytes())
+        .assert_stdout_is_empty();
+}
+
+#[test]
+fn test_library_version_older_than_runner_version() {
+    let runner_version = common::get_runner_version();
+    let library_version = {
+        let mut library_version = runner_version.clone();
+        // just to be sure we decrement at least one part because decrement saturates at 0
+        library_version.decrement("major");
+        library_version.decrement("minor");
+        library_version.decrement("patch");
+        library_version
+    };
+
+    let expected_stderr = format!(
+        "iai_callgrind_runner: Error: iai-callgrind-runner ({runner_version}) is newer than \
+         iai-callgrind ({library_version}). Please update iai-callgrind to '{runner_version}' in \
+         your Cargo.toml file\n"
+    );
+
+    common::Runner::new()
+        .args(&[&library_version.to_string()])
+        .run()
+        .assert_stderr_bytes(expected_stderr.as_bytes())
+        .assert_stdout_is_empty();
+}
+
+// We still error out here because we don't supply the rest of the necessary arguments
+#[test]
+fn test_library_version_equals_runner_version() {
+    let version = common::get_runner_version();
+    let expected_stderr = format!(
+        "iai_callgrind_runner: Error: Failed to initialize iai-callgrind-runner: Unexpected \
+         number of arguments\n\nDetected version of iai-callgrind-runner is {version}. This error \
+         can be caused by a version mismatch between iai-callgrind and iai-callgrind-runner. If \
+         you updated the library (iai-callgrind) in your Cargo.toml file, the binary \
+         (iai-callgrind-runner) needs to be updated to the same version and vice versa.\n"
+    );
+
+    common::Runner::new()
+        .args(&[&version.to_string()])
+        .run()
+        .assert_stderr_bytes(expected_stderr.as_bytes())
+        .assert_stdout_is_empty();
+}
+
+// This can happen with versions of `iai-callgrind` < 0.3.0 because we don't submit the library
+// version as first argument
+#[test]
+fn test_library_version_not_submitted() {
+    let runner_version = common::get_runner_version();
+    let expected_stderr = format!(
+        "iai_callgrind_runner: Error: No version information found for iai-callgrind but \
+         iai-callgrind-runner ({runner_version}) is >= '0.3.0'. Please update iai-callgrind to \
+         '{runner_version}' in your Cargo.toml file\n"
+    );
+
+    common::Runner::new()
+        .args(&["no version"])
+        .run()
+        .assert_stderr_bytes(expected_stderr.as_bytes())
+        .assert_stdout_is_empty();
+}

--- a/iai-callgrind-runner/tests/tests.rs
+++ b/iai-callgrind-runner/tests/tests.rs
@@ -4,4 +4,6 @@ mod common;
 mod test_callgrind;
 
 #[cfg(test)]
+mod test_runner_binary;
+#[cfg(test)]
 mod test_tools;


### PR DESCRIPTION
Error messages as seen in #161 are not very helpful.

This pr adds better error messages with a solution hint if parsing the iai-callgrind-runner arguments fails. The parsing errors almost always happen because the iai-callgrind library and the iai-callgrind-runner binary have different versions. Also, the actual version check now takes place a lot sooner.