### PR TITLE
lint: Fix clippy warnings

### DIFF
--- a/client-request-tests/tests/fixtures/cachegrind-reqs-test.since_1.79.0.armv7.stderr
+++ b/client-request-tests/tests/fixtures/cachegrind-reqs-test.since_1.79.0.armv7.stderr
@@ -1,4 +1,4 @@
-Reading EXIDX entries: 418 available
+Reading EXIDX entries: 397 available
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -7,8 +7,8 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
+Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -16,6 +16,7 @@ Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
+Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -28,13 +29,10 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
@@ -67,9 +65,6 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -81,8 +76,8 @@ Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
+Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -117,7 +112,6 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -135,10 +129,9 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
+Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -189,7 +182,6 @@ Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -214,9 +206,7 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
@@ -228,7 +218,6 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
@@ -292,18 +281,11 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
@@ -357,7 +339,7 @@ Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryExtract: bytecode can't be represented
 Warning: whilst reading EXIDX: ExtabEntryDecode: failed with error code: -10
-Reading EXIDX entries: 413 attempted, 55 successful
+Reading EXIDX entries: 392 attempted, 52 successful
 result: 90
 
 I refs:        <__FILTER__>

--- a/iai-callgrind-runner/src/runner/callgrind/mod.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/mod.rs
@@ -90,7 +90,7 @@ impl CallgrindCommand {
         } else {
             callgrind_args.collect_atstart = true;
         }
-        callgrind_args.set_output_file(&output_path.to_path());
+        callgrind_args.set_output_file(output_path.to_path());
         callgrind_args.set_log_arg(output_path);
 
         let callgrind_args = callgrind_args.to_vec();

--- a/iai-callgrind/src/client_requests/valgrind.rs
+++ b/iai-callgrind/src/client_requests/valgrind.rs
@@ -266,11 +266,11 @@ pub fn count_errors() -> usize {
 /// function. For Memcheck (an illustrative case), this does two things:
 ///
 /// - It records that the block has been allocated.  This means any addresses within the block
-/// mentioned in error messages will be identified as belonging to the block.  It also means that if
-/// the block isn't freed it will be detected by the leak checker.
+///   mentioned in error messages will be identified as belonging to the block.  It also means that
+///   if the block isn't freed it will be detected by the leak checker.
 /// - It marks the block as being addressable and undefined (if `is_zeroed` is not set), or
-/// addressable and defined (if `is_zeroed` is set). This controls how accesses to the block by the
-/// program are handled.
+///   addressable and defined (if `is_zeroed` is set). This controls how accesses to the block by
+///   the program are handled.
 ///
 /// `addr` is the start of the usable block (ie. after any redzone), `size` is its size. `redzone`
 /// is the redzone size if the allocator can apply redzones -- these are blocks of padding at the
@@ -329,10 +329,11 @@ pub fn malloclike_block(addr: *const (), size: usize, redzone: usize, is_zeroed:
 /// For Memcheck, it does four things:
 ///
 /// - It records that the size of a block has been changed. This assumes that the block was
-/// annotated as having been allocated via [`malloclike_block`]. Otherwise, an error will be issued.
+///   annotated as having been allocated via [`malloclike_block`]. Otherwise, an error will be
+///   issued.
 /// - If the block shrunk, it marks the freed memory as being unaddressable.
 /// - If the block grew, it marks the new area as undefined and defines a red zone past the end of
-/// the new block.
+///   the new block.
 /// - The V-bits of the overlap between the old and the new block are preserved.
 ///
 /// `resizeinplace_block` should be put after allocation of the new block and before deallocation of
@@ -358,7 +359,7 @@ pub fn resizeinplace_block(addr: *const (), old_size: usize, new_size: usize, re
 /// file.
 ///
 /// - It records that the block has been deallocated. This assumes that the block was annotated as
-/// having been allocated via [`malloclike_block`]. Otherwise, an error will be issued.
+///   having been allocated via [`malloclike_block`]. Otherwise, an error will be issued.
 /// - It marks the block as being unaddressable.
 ///
 /// `freelike_block` should be put immediately after the point where a heap block is deallocated.

--- a/iai-callgrind/src/lib.rs
+++ b/iai-callgrind/src/lib.rs
@@ -21,28 +21,26 @@
 //!
 //! ## Characteristics
 //! - __Precision__: High-precision measurements allow you to reliably detect very small
-//! optimizations of your code
+//!   optimizations of your code
 //! - __Consistency__: Iai-Callgrind can take accurate measurements even in virtualized CI
-//! environments
+//!   environments
 //! - __Performance__: Since Iai-Callgrind only executes a benchmark once, it is typically a lot
-//! faster to run than benchmarks measuring the execution and wall time
+//!   faster to run than benchmarks measuring the execution and wall time
 //! - __Regression__: Iai-Callgrind reports the difference between benchmark runs to make it easy to
-//! spot detailed performance regressions and improvements.
+//!   spot detailed performance regressions and improvements.
 //! - __CPU and Cache Profiling__: Iai-Callgrind generates a Callgrind profile of your code while
-//! benchmarking, so you can use Callgrind-compatible tools like
-//! [callgrind_annotate](https://valgrind.org/docs/manual/cl-manual.html#cl-manual.callgrind_annotate-options)
-//! or the visualizer [kcachegrind](https://kcachegrind.github.io/html/Home.html) to analyze the
-//! results in detail.
-//! - __Memory Profiling__: You can run other Valgrind tools like [DHAT: a dynamic heap analysis
-//! tool](https://valgrind.org/docs/manual/dh-manual.html) and [Massif: a heap
-//! profiler](https://valgrind.org/docs/manual/ms-manual.html) with the Iai-Callgrind benchmarking
-//! framework. Their profiles are stored next to the callgrind profiles and are ready to be examined
-//! with analyzing tools like `dh_view.html`, `ms_print` and others.
+//!   benchmarking, so you can use Callgrind-compatible tools like
+//!   [callgrind_annotate](https://valgrind.org/docs/manual/cl-manual.html#cl-manual.callgrind_annotate-options)
+//!   or the visualizer [kcachegrind](https://kcachegrind.github.io/html/Home.html) to analyze the
+//!   results in detail.
+//! - __Memory Profiling__: You can run other Valgrind tools like [DHAT: a dynamic heap analysis tool](https://valgrind.org/docs/manual/dh-manual.html)
+//!   and [Massif: a heap profiler](https://valgrind.org/docs/manual/ms-manual.html) with the
+//!   Iai-Callgrind benchmarking framework. Their profiles are stored next to the callgrind profiles
+//!   and are ready to be examined with analyzing tools like `dh_view.html`, `ms_print` and others.
 //! - __Visualization__: Iai-Callgrind is capable of creating regular and differential flamegraphs
-//! from the Callgrind output format.
-//! - __Valgrind Client Requests__: Support of zero overhead [Valgrind Client
-//! Requests](https://valgrind.org/docs/manual/manual-core-adv.html#manual-core-adv.clientreq)
-//! (compared to native valgrind client requests overhead) on many targets
+//!   from the Callgrind output format.
+//! - __Valgrind Client Requests__: Support of zero overhead [Valgrind Client Requests](https://valgrind.org/docs/manual/manual-core-adv.html#manual-core-adv.clientreq)
+//!   (compared to native valgrind client requests overhead) on many targets
 //! - __Stable-compatible__: Benchmark your code without installing nightly Rust
 //!
 //! ## Benchmarking

--- a/iai-callgrind/src/lib_bench.rs
+++ b/iai-callgrind/src/lib_bench.rs
@@ -76,8 +76,8 @@ impl LibraryBenchmarkConfig {
     /// * `--D1=32768,8,64`
     /// * `--LL=8388608,16,64`
     /// * `--cache-sim=yes` (can't be changed)
-    /// * `--toggle-collect=*BENCHMARK_FILE::BENCHMARK_FUNCTION` (this first toggle can't
-    /// be changed)
+    /// * `--toggle-collect=*BENCHMARK_FILE::BENCHMARK_FUNCTION` (this first toggle can't be
+    ///   changed)
     /// * `--collect-atstart=no` (overwriting this setting will have no effect)
     /// * `--compress-pos=no`
     /// * `--compress-strings=no`

--- a/iai-callgrind/src/macros.rs
+++ b/iai-callgrind/src/macros.rs
@@ -40,10 +40,10 @@
 ///
 /// which accepts the following top-level arguments:
 ///
-/// * __`library_benchmark_groups`__ (mandatory): The `name` of one or
-/// more [`library_benchmark_group!`](crate::library_benchmark_group) macros.
-/// * __`config`__ (optional): Optionally specify a [`crate::LibraryBenchmarkConfig`]
-/// valid for all benchmark groups
+/// * __`library_benchmark_groups`__ (mandatory): The `name` of one or more
+///   [`library_benchmark_group!`](crate::library_benchmark_group) macros.
+/// * __`config`__ (optional): Optionally specify a [`crate::LibraryBenchmarkConfig`] valid for all
+///   benchmark groups
 ///
 /// A library benchmark consists of
 /// [`library_benchmark_groups`](crate::library_benchmark_group) and  with
@@ -744,10 +744,10 @@ binary_benchmark_group!(name = some_ident; benchmark = |"my_exe", group: &mut Bi
 ///
 /// * `__name__` (mandatory): A unique name used to identify the group for the `main!` macro
 /// * `__config__` (optional): A [`crate::LibraryBenchmarkConfig`] which is applied to all
-/// benchmarks within the same group.
+///   benchmarks within the same group.
 /// * `__compare_by_id__` (optional): The default is false. If true, all benches in the benchmark
-/// functions specified with the `benchmarks` argument, across any benchmark groups, are compared
-/// with each other as long as the ids (the part after the `::` in `#[bench::id(...)]`) match.
+///   functions specified with the `benchmarks` argument, across any benchmark groups, are compared
+///   with each other as long as the ids (the part after the `::` in `#[bench::id(...)]`) match.
 #[macro_export]
 macro_rules! library_benchmark_group {
     (


### PR DESCRIPTION
Fix various clippy warnings occurring since latest stable 1.80. Also, the stable release changed the output of the client requests on arm.