### PR TITLE
feat(truncate): Support adjustable truncation of description in output header

### DIFF
--- a/iai-callgrind-runner/src/api.rs
+++ b/iai-callgrind-runner/src/api.rs
@@ -41,6 +41,7 @@ pub struct BinaryBenchmarkConfig {
     pub regression_config: Option<RegressionConfig>,
     pub tools: Tools,
     pub tools_override: Option<Tools>,
+    pub truncate_description: Option<Option<usize>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -208,6 +209,7 @@ pub struct LibraryBenchmarkConfig {
     pub regression_config: Option<RegressionConfig>,
     pub tools: Tools,
     pub tools_override: Option<Tools>,
+    pub truncate_description: Option<Option<usize>>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -451,6 +453,8 @@ impl LibraryBenchmarkConfig {
             } else {
                 // do nothing
             }
+            self.truncate_description =
+                update_option(&self.truncate_description, &other.truncate_description);
         }
         self
     }
@@ -592,6 +596,7 @@ mod tests {
                 show_log: None,
             }]),
             tools_override: None,
+            truncate_description: None,
         };
 
         assert_eq!(base.update_from_all([Some(&other.clone())]), other);
@@ -614,6 +619,7 @@ mod tests {
                 show_log: None,
             }]),
             tools_override: Some(Tools(vec![])),
+            truncate_description: None,
         };
         let expected = LibraryBenchmarkConfig {
             tools: other.tools_override.as_ref().unwrap().clone(),

--- a/iai-callgrind-runner/src/runner/bin_bench.rs
+++ b/iai-callgrind-runner/src/runner/bin_bench.rs
@@ -75,6 +75,7 @@ struct BinBench {
     flamegraph_config: Option<FlamegraphConfig>,
     regression_config: Option<RegressionConfig>,
     tools: ToolConfigs,
+    truncate_description: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -350,6 +351,7 @@ impl Benchmarkable for Assistant {
             [&group.module_path, &self.kind.id(), &self.name],
             None,
             None,
+            None,
         );
 
         if meta.args.output_format == OutputFormat::Default {
@@ -481,7 +483,12 @@ impl Benchmarkable for BinBench {
     }
 
     fn print_header(&self, meta: &Metadata, group: &Group) -> Header {
-        let header = Header::new(&group.module_path, self.id.clone(), self.to_string());
+        let header = Header::new(
+            &group.module_path,
+            self.id.clone(),
+            self.to_string(),
+            self.truncate_description,
+        );
 
         if meta.args.output_format == OutputFormat::Default {
             header.print();
@@ -652,6 +659,7 @@ impl Groups {
                     flamegraph_config: flamegraph_config.clone(),
                     regression_config: regression_config.clone(),
                     tools: tools.clone(),
+                    truncate_description: config.truncate_description.unwrap_or(Some(50)),
                 });
             }
         }

--- a/iai-callgrind-runner/src/runner/lib_bench.rs
+++ b/iai-callgrind-runner/src/runner/lib_bench.rs
@@ -78,6 +78,7 @@ struct LibBench {
     flamegraph_config: Option<FlamegraphConfig>,
     regression_config: Option<RegressionConfig>,
     tools: ToolConfigs,
+    truncate_description: Option<usize>,
 }
 
 /// Implements [`Benchmark`] to load a [`LibBench`] baseline run and compare against another
@@ -383,6 +384,7 @@ impl Groups {
                         )
                         .map(Into::into),
                         tools: ToolConfigs(config.tools.0.into_iter().map(Into::into).collect()),
+                        truncate_description: config.truncate_description.unwrap_or(Some(50)),
                     };
                     group.benches.push(lib_bench);
                 }
@@ -514,6 +516,7 @@ impl LibBench {
             [&group.module, &self.function],
             self.id.clone(),
             self.args.clone(),
+            self.truncate_description,
         );
 
         if meta.args.output_format == OutputFormat::Default {

--- a/iai-callgrind/src/bin_bench.rs
+++ b/iai-callgrind/src/bin_bench.rs
@@ -843,6 +843,48 @@ impl BinaryBenchmarkConfig {
             .update_all(tools.into_iter().map(Into::into));
         self
     }
+
+    /// Adjust, enable or disable the truncation of the description in the iai-callgrind output
+    ///
+    /// The default is to truncate the description to the size of 50 ascii characters. A `None`
+    /// value disables the truncation entirely and a `Some` value will truncate the description to
+    /// the given amount of characters excluding the ellipsis.
+    ///
+    /// To clearify which part of the output is meant by `DESCRIPTION`:
+    ///
+    /// ```text
+    /// benchmark_file::group_name id:DESCRIPTION
+    ///   Instructions:              352135|352135          (No change)
+    ///   L1 Hits:                   470117|470117          (No change)
+    ///   L2 Hits:                      748|748             (No change)
+    ///   RAM Hits:                    4112|4112            (No change)
+    ///   Total read+write:          474977|474977          (No change)
+    ///   Estimated Cycles:          617777|617777          (No change)
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// For example, specifying this option with a `None` value in the `main!` macro disables the
+    /// truncation of the description for all benchmarks.
+    ///
+    /// ```rust
+    /// use iai_callgrind::{main, BinaryBenchmarkConfig};
+    /// # use iai_callgrind::binary_benchmark_group;
+    /// # binary_benchmark_group!(
+    /// #    name = some_group;
+    /// #    benchmark = |"", group: &mut BinaryBenchmarkGroup| {}
+    /// # );
+    /// # fn main() {
+    /// main!(
+    ///     config = BinaryBenchmarkConfig::default().truncate_description(None);
+    ///     binary_benchmark_groups = some_group
+    /// );
+    /// # }
+    /// ```
+    pub fn truncate_description(&mut self, value: Option<usize>) -> &mut Self {
+        self.0.truncate_description = Some(value);
+        self
+    }
 }
 
 impl_traits!(

--- a/iai-callgrind/src/lib_bench.rs
+++ b/iai-callgrind/src/lib_bench.rs
@@ -60,6 +60,7 @@ impl LibraryBenchmarkConfig {
             regression_config: Option::default(),
             tools: internal::InternalTools::default(),
             tools_override: Option::default(),
+            truncate_description: Option::default(),
         })
     }
 
@@ -516,6 +517,50 @@ impl LibraryBenchmarkConfig {
             .tools_override
             .get_or_insert(internal::InternalTools::default())
             .update_all(tools.into_iter().map(Into::into));
+        self
+    }
+
+    /// Adjust, enable or disable the truncation of the description in the iai-callgrind output
+    ///
+    /// The default is to truncate the description to the size of 50 ascii characters. A `None`
+    /// value disables the truncation entirely and a `Some` value will truncate the description to
+    /// the given amount of characters excluding the ellipsis.
+    ///
+    /// To clearify which part of the output is meant by `DESCRIPTION`:
+    ///
+    /// ```text
+    /// benchmark_file::group_name::function_name id:DESCRIPTION
+    ///   Instructions:              352135|352135          (No change)
+    ///   L1 Hits:                   470117|470117          (No change)
+    ///   L2 Hits:                      748|748             (No change)
+    ///   RAM Hits:                    4112|4112            (No change)
+    ///   Total read+write:          474977|474977          (No change)
+    ///   Estimated Cycles:          617777|617777          (No change)
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// For example, specifying this option with a `None` value in the `main!` macro disables the
+    /// truncation of the description for all benchmarks.
+    ///
+    /// ```rust
+    /// use iai_callgrind::{main, LibraryBenchmarkConfig};
+    /// # use iai_callgrind::{library_benchmark, library_benchmark_group};
+    /// # #[library_benchmark]
+    /// # fn some_func() {}
+    /// # library_benchmark_group!(
+    /// #    name = some_group;
+    /// #    benchmarks = some_func
+    /// # );
+    /// # fn main() {
+    /// main!(
+    ///     config = LibraryBenchmarkConfig::default().truncate_description(None);
+    ///     library_benchmark_groups = some_group
+    /// );
+    /// # }
+    /// ```
+    pub fn truncate_description(&mut self, value: Option<usize>) -> &mut Self {
+        self.0.truncate_description = Some(value);
         self
     }
 }


### PR DESCRIPTION
This pr adds an option to `LibraryBenchmarkConfig` and `BinaryBenchmarkConfig` to make the truncation of the `DESCRIPTION` in the output header adjustable.

```
benchmark_file::group_name::function_name id:DESCRIPTION
  Instructions:              352135|352135          (No change)
  L1 Hits:                   470117|470117          (No change)
  L2 Hits:                      748|748             (No change)
  RAM Hits:                    4112|4112            (No change)
  Total read+write:          474977|474977          (No change)
  Estimated Cycles:          617777|617777          (No change)
```

Per default the `DESCRIPTION` is truncated to the width of 50 ascii characters but can be changed to any `usize` or switched off entirely.

Related #207 