### PR TITLE
fix(summary_parser): extract "totals" when "summary" is "0"

### DIFF
--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -20,9 +20,7 @@ version = "0.1.0"
 cargo_metadata = { workspace = true }
 colored = { workspace = true }
 glob = { workspace = true }
-iai-callgrind = { path = "../iai-callgrind", features = [
-  "client_requests_defs",
-] }
+iai-callgrind = { path = "../iai-callgrind", features = ["client_requests"] }
 # Needed in the `cargo bench` wrapper
 iai-callgrind-runner = { path = "../iai-callgrind-runner" }
 lazy_static = { workspace = true }
@@ -71,6 +69,10 @@ path = "src/helper/env.rs"
 [[bin]]
 name = "exit-with"
 path = "src/helper/exit-with.rs"
+
+[[bin]]
+name = "client-requests"
+path = "src/helper/client-requests.rs"
 
 [[bench]]
 harness = false
@@ -195,3 +197,8 @@ path = "benches/test_lib_bench/file_parameter/test_lib_bench_file_parameter.rs"
 [[bench]]
 harness = false
 name = "test_bench_template"
+
+[[bench]]
+harness = false
+name = "test_bin_bench_client_requests"
+path = "benches/test_bin_bench/client_requests/test_bin_bench_client_requests.rs"

--- a/benchmark-tests/benches/test_bin_bench/client_requests/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/client_requests/expected_stdout.1
@@ -1,0 +1,9 @@
+test_bin_bench_client_requests::client_requests::run parse_output:() -> target/release/client-requests
+Hello World.
+- end of stdout/stderr
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)

--- a/benchmark-tests/benches/test_bin_bench/client_requests/test_bin_bench_client_requests.conf.yml
+++ b/benchmark-tests/benches/test_bin_bench/client_requests/test_bin_bench_client_requests.conf.yml
@@ -1,0 +1,5 @@
+groups:
+  - runs:
+      - args: ["--nocapture"]
+        expected:
+          stdout: expected_stdout.1

--- a/benchmark-tests/benches/test_bin_bench/client_requests/test_bin_bench_client_requests.rs
+++ b/benchmark-tests/benches/test_bin_bench/client_requests/test_bin_bench_client_requests.rs
@@ -1,0 +1,21 @@
+use iai_callgrind::{
+    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Command,
+};
+
+#[binary_benchmark]
+#[bench::parse_output()]
+fn run() -> Command {
+    let path = env!("CARGO_BIN_EXE_client-requests");
+    Command::new(path).build()
+}
+
+binary_benchmark_group!(
+    name = client_requests;
+    config = BinaryBenchmarkConfig::default()
+        .raw_callgrind_args([
+            "--instr-atstart=no"
+    ]);
+    benchmarks = run,
+);
+
+main!(binary_benchmark_groups = client_requests);

--- a/benchmark-tests/src/helper/client-requests.rs
+++ b/benchmark-tests/src/helper/client-requests.rs
@@ -1,0 +1,5 @@
+fn main() {
+    iai_callgrind::client_requests::callgrind::start_instrumentation();
+    println!("Hello World.");
+    iai_callgrind::client_requests::callgrind::stop_instrumentation();
+}

--- a/iai-callgrind-runner/src/runner/callgrind/summary_parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/summary_parser.rs
@@ -30,6 +30,13 @@ impl Parser for SummaryParser {
             if let Some(stripped) = line.strip_prefix("summary:") {
                 trace!("Found line with summary: '{}'", line);
                 costs.add_iter_str(stripped.split_ascii_whitespace());
+                if costs.iter().all(|(_c, u)| *u == 0) {
+                    trace!(
+                        "Continuing file processing as summary indicates \"client_request\" are \
+                         used."
+                    );
+                    continue;
+                };
                 trace!("Updated counters to '{:?}'", &costs);
                 found = true;
                 break;


### PR DESCRIPTION
using client_requests::callgrind::start_instrumentation() and stop_instrumentation() leads to summary with a "0" value skipping summary in that case to use totals which are present