### PR TITLE
feat: Add adjustable entry point (default toggle)

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -1,3 +1,4 @@
+inlines
 ASLR
 Aparicio
 Assche

--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -43,6 +43,7 @@ Valgrind's
 Valgrinds
 Weidendorfer
 aarch
+ackermann
 addressibility
 ahash
 armv7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* ([#254](https://github.com/iai-callgrind/iai-callgrind/pull/254)): Added the
+  option to switch off the entry point `EntryPoint::None` or use a custom entry
+  point (`EntryPoint::Custom`). The default entry point stays the same and is
+  the toggle Iai-Callgrind sets with `--toggle-collect` to the benchmark
+  function.
+
+### Changed
+
+* ([#254](https://github.com/iai-callgrind/iai-callgrind/pull/254)): Due to the
+  changes required to handle the different entry points options, the flamegraphs
+  created in binary benchmarks and flamegraphs from library benchmarks with
+  `EntryPoint::None` include all events, not only the events from `main`
+  downwards.
+
 ## [0.13.2] - 2024-09-03
 
 ### Fixed

--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -197,6 +197,11 @@ path = "benches/test_lib_bench/file_parameter/test_lib_bench_file_parameter.rs"
 
 [[bench]]
 harness = false
+name = "test_lib_bench_entry_point"
+path = "benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs"
+
+[[bench]]
+harness = false
 name = "test_bench_template"
 
 [[bench]]

--- a/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.conf.yml
@@ -1,0 +1,3 @@
+groups:
+  - runs:
+      - args: ["--nocapture"]

--- a/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
+++ b/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
@@ -2,7 +2,8 @@ use std::hint::black_box;
 
 use benchmark_tests::assert::Assert;
 use iai_callgrind::{
-    library_benchmark, library_benchmark_group, main, EntryPoint, EventKind, LibraryBenchmarkConfig,
+    library_benchmark, library_benchmark_group, main, EntryPoint, EventKind, FlamegraphConfig,
+    LibraryBenchmarkConfig,
 };
 use iai_callgrind_runner::runner::callgrind::hashmap_parser::SourcePath;
 use iai_callgrind_runner::runner::summary::BenchmarkSummary;
@@ -126,5 +127,10 @@ fn assert_benchmarks() {
     assert_nested();
 }
 
-library_benchmark_group!(name = my_group; teardown = assert_benchmarks(); benchmarks = bench_lib);
+library_benchmark_group!(
+    name = my_group;
+    config = LibraryBenchmarkConfig::default().flamegraph(FlamegraphConfig::default());
+    teardown = assert_benchmarks();
+    benchmarks = bench_lib
+);
 main!(library_benchmark_groups = my_group);

--- a/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
+++ b/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
@@ -1,0 +1,39 @@
+use std::hint::black_box;
+
+use iai_callgrind::{
+    library_benchmark, library_benchmark_group, main, EntryPoint, LibraryBenchmarkConfig,
+};
+
+#[inline(never)]
+fn nested() -> u64 {
+    benchmark_tests::fibonacci(10)
+}
+
+#[inline(never)]
+fn some_func() -> u64 {
+    nested()
+}
+
+#[library_benchmark()]
+#[bench::none(
+    config = LibraryBenchmarkConfig::default()
+        .entry_point(EntryPoint::None)
+)]
+#[bench::default(
+    config = LibraryBenchmarkConfig::default()
+        .entry_point(EntryPoint::Default)
+)]
+#[bench::some(
+    config = LibraryBenchmarkConfig::default()
+        .entry_point(EntryPoint::from("test_lib_bench_entry_point::nested"))
+)]
+#[bench::other(
+    config = LibraryBenchmarkConfig::default()
+        .entry_point("test_lib_bench_entry_point::nested"),
+)]
+fn bench_lib() -> u64 {
+    black_box(some_func())
+}
+
+library_benchmark_group!(name = my_group; benchmarks = bench_lib);
+main!(library_benchmark_groups = my_group);

--- a/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
+++ b/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
@@ -1,8 +1,11 @@
 use std::hint::black_box;
 
+use benchmark_tests::assert::Assert;
 use iai_callgrind::{
-    library_benchmark, library_benchmark_group, main, EntryPoint, LibraryBenchmarkConfig,
+    library_benchmark, library_benchmark_group, main, EntryPoint, EventKind, LibraryBenchmarkConfig,
 };
+use iai_callgrind_runner::runner::callgrind::hashmap_parser::SourcePath;
+use iai_callgrind_runner::runner::summary::BenchmarkSummary;
 
 #[inline(never)]
 fn nested() -> u64 {
@@ -14,26 +17,114 @@ fn some_func() -> u64 {
     nested()
 }
 
-#[library_benchmark()]
+#[library_benchmark]
 #[bench::none(
     config = LibraryBenchmarkConfig::default()
-        .entry_point(EntryPoint::None)
+        .entry_point(EntryPoint::None),
 )]
 #[bench::default(
     config = LibraryBenchmarkConfig::default()
         .entry_point(EntryPoint::Default)
 )]
-#[bench::some(
+#[bench::nested(
     config = LibraryBenchmarkConfig::default()
         .entry_point(EntryPoint::from("test_lib_bench_entry_point::nested"))
-)]
-#[bench::other(
-    config = LibraryBenchmarkConfig::default()
-        .entry_point("test_lib_bench_entry_point::nested"),
 )]
 fn bench_lib() -> u64 {
     black_box(some_func())
 }
 
-library_benchmark_group!(name = my_group; benchmarks = bench_lib);
+// We need to check some gory details in the group teardown to see if the entry point is being
+// applied correctly.
+fn assert_none() {
+    let assert = Assert::new(module_path!(), "my_group", "bench_lib", "none").unwrap();
+    assert
+        .summary(|b| {
+            let new_ir = b.callgrind_summary.unwrap().summaries[0]
+                .events
+                .diff_by_kind(&EventKind::Ir)
+                .unwrap()
+                .new
+                .unwrap();
+            new_ir > 400000
+        })
+        .unwrap();
+}
+
+fn assert_default() {
+    let check_summary = |b: BenchmarkSummary| {
+        let new_ir = b.callgrind_summary.unwrap().summaries[0]
+            .events
+            .diff_by_kind(&EventKind::Ir)
+            .unwrap()
+            .new
+            .unwrap();
+        new_ir < 3000
+    };
+
+    let assert = Assert::new(module_path!(), "my_group", "bench_lib", "default").unwrap();
+    assert.summary(check_summary).unwrap();
+    assert
+        .callgrind_map(|m| {
+            let main_costs = m.map
+                .iter()
+                .find_map(|(k, v)| (k.func == "main").then(|| v.costs.clone()))
+                .unwrap();
+
+            let benchmark_function_costs = m.map
+                    .iter()
+                    .find_map(|(k, v)| {
+                        (
+                            k.func == "test_lib_bench_entry_point::bench_lib::__iai_callgrind_wrapper_mod::bench_lib" &&
+                            k.file == Some(SourcePath::Relative(file!().into()))
+                        )
+                        .then(|| v.costs.clone())
+                    })
+                    .unwrap();
+            main_costs == benchmark_function_costs
+        })
+        .unwrap();
+}
+
+fn assert_nested() {
+    let check_summary = |b: BenchmarkSummary| {
+        let new_ir = b.callgrind_summary.unwrap().summaries[0]
+            .events
+            .diff_by_kind(&EventKind::Ir)
+            .unwrap()
+            .new
+            .unwrap();
+        new_ir < 3000
+    };
+
+    let assert = Assert::new(module_path!(), "my_group", "bench_lib", "nested").unwrap();
+    assert.summary(check_summary).unwrap();
+    assert
+        .callgrind_map(|m| {
+            let main_costs = m
+                .map
+                .iter()
+                .find_map(|(k, v)| (k.func == "main").then(|| v.costs.clone()))
+                .unwrap();
+            let nested_function_costs = m
+                .map
+                .iter()
+                .find_map(|(k, v)| {
+                    (k.func == "test_lib_bench_entry_point::nested"
+                        && k.file == Some(SourcePath::Relative(file!().into())))
+                    .then(|| v.costs.clone())
+                })
+                .unwrap();
+            main_costs == nested_function_costs
+        })
+        .unwrap();
+}
+
+fn assert_benchmarks() {
+    assert_none();
+    assert_default();
+    assert_nested();
+}
+
+library_benchmark_group!(name = my_group; teardown = assert_benchmarks(); benchmarks = bench_lib);
 main!(library_benchmark_groups = my_group);

--- a/cspell.json
+++ b/cspell.json
@@ -23,6 +23,7 @@
     "benchmark-tests/fixtures",
     "benchmark-tests/fixtures-with-symlinks",
     "benchmark-tests/benches/test_bin_bench_groups.fixtures",
-    "docs/theme/*"
+    "docs/theme/*",
+    "**/*.svg"
   ]
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD025 MD042 -->
+<!-- TODO: Add entry point customization -->
 # Summary
 
 - [Introduction](./intro.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,5 +1,4 @@
 <!-- markdownlint-disable MD025 MD042 -->
-<!-- TODO: Add entry point customization -->
 # Summary
 
 - [Introduction](./intro.md)
@@ -23,6 +22,7 @@
     - [Generic benchmark functions](./benchmarks/library_benchmarks/generic.md)
     - [Comparing benchmark functions](./benchmarks/library_benchmarks/compare_by_id.md)
     - [Configuration](./benchmarks/library_benchmarks/configuration.md)
+    - [Custom entry points](./benchmarks/library_benchmarks/custom_entry_point.md)
     - [More Examples, please!](./benchmarks/library_benchmarks/examples.md)
 - [Binary Benchmarks](./benchmarks/binary_benchmarks.md)
     - [Important default behaviour](./benchmarks/binary_benchmarks/important.md)

--- a/docs/src/benchmarks/library_benchmarks/custom_entry_point.md
+++ b/docs/src/benchmarks/library_benchmarks/custom_entry_point.md
@@ -1,0 +1,113 @@
+# Custom entry points
+
+To understand custom entry points let's take a small detour into how
+[`Callgrind`][Callgrind] and Iai-Callgrind work under the hood.
+
+## Iai-Callgrind under the hood
+
+`Callgrind` collects metrics and associates them with a function. This happens
+based on the compiled code not the source code, so it is possible to hook into
+any function not only public functions. `Callgrind` can be configured to switch
+instrumentation on and off based on a function name with
+[`--toggle-collect`][Callgrind Arguments]. Per default, Iai-Callgrind sets this
+toggle (which we call [`EntryPoint`]) to the benchmarking function. Setting the
+toggle implies `--collect-at-start=no`. So, all events before (in the `setup`)
+and after the benchmark function (in the `teardown`) are not collected. Somewhat
+simplified, but conveying the basic idea, here is a commented example:
+
+```rust
+// <-- collect-at-start=no
+
+# extern crate iai_callgrind;
+# mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
+use iai_callgrind::{main,library_benchmark_group, library_benchmark};
+use std::hint::black_box;
+
+#[library_benchmark]
+fn bench() -> Vec<i32> { // <-- DEFAULT ENTRY POINT starts collecting events
+    black_box(my_lib::bubble_sort(vec![3, 2, 1]))
+} // <-- stop collecting events
+
+library_benchmark_group!( name = my_group; benchmarks = bench);
+# fn main() {
+main!(library_benchmark_groups = my_group);
+# }
+```
+
+### Pitfall: Inlined functions
+
+The fact that `Callgrind` acts on the compiled code harbors a pitfall. The
+compiler with compile-time optimizations switched on (which is usually the case
+when compiling benchmarks) inlines functions if it sees an advantage in doing
+so. Iai-Callgrind takes care, that this doesn't happen with the benchmark
+function, so `Callgrind` can find and hook into the benchmark function. But, in
+your production code you actually don't want to stop the compiler from doing
+it's job just to be able to benchmark that function. So, be cautious with
+benchmarking private functions and only choose functions of which it is known
+that they are not being inlined.
+
+## Hook into private functions
+
+The basic idea is to choose a public function in your library acting as access
+point to the actual function you want to benchmark. As outlined before, this
+works only reliably for functions which are not inlined by the compiler.
+
+```rust
+# extern crate iai_callgrind;
+use iai_callgrind::{
+    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
+    EntryPoint
+};
+use std::hint::black_box;
+
+mod my_lib {
+     #[inline(never)]
+     fn bubble_sort(input: Vec<i32>) -> Vec<i32> {
+         // The algorithm
+#        input
+     }
+
+     pub fn access_point(input: Vec<i32>) -> Vec<i32> {
+         println!("Doing something before the function call");
+         bubble_sort(input)
+     }
+}
+
+#[library_benchmark(
+    config = LibraryBenchmarkConfig::default()
+        .entry_point(EntryPoint::Custom("*::my_lib::bubble_sort".to_owned()))
+)]
+#[bench::small(vec![3, 2, 1])]
+#[bench::bigger(vec![5, 4, 3, 2, 1])]
+fn bench_private(array: Vec<i32>) -> Vec<i32> {
+    black_box(my_lib::access_point(array))
+}
+
+library_benchmark_group!(name = my_group; benchmarks = bench_private);
+# fn main() {
+main!(library_benchmark_groups = my_group);
+# }
+```
+
+Note the `#[inline(never)]` we use in this example to make sure the
+`bubble_sort` function is not getting inlined.
+
+We use a [wildcard][Callgrind Arguments] `*::my_lib::bubble_sort` for
+`EntryPoint::Custom` for demonstration purposes. You might want to tighten this
+pattern. If you don't know how the pattern looks like, use `EntryPoint::None`
+first then run the benchmark. Now, investigate the [callgrind output
+file](../../cli_and_env/output/out_directory.md). This output file is pretty
+low-level but all you need to do is search for the entries which start with
+`fn=...`. In the example above this entry might look like
+`fn=algorithms::my_lib::bubble_sort` if `my_lib` would be part of the top-level
+`algorithms` module. Or, using grep:
+
+```shell
+grep '^fn=.*::bubble_sort$' target/iai/the_package/benchmark_file_name/my_group/bench_private.bigger/callgrind.bench_private.bigger.out
+```
+
+Having found the pattern, you can eventually use `EntryPoint::Custom`.
+
+[Callgrind]: https://valgrind.org/docs/manual/cl-manual.html
+[Callgrind Arguments]: https://valgrind.org/docs/manual/cl-manual.html#cl-manual.options
+[`EntryPoint`]: https://docs.rs/iai-callgrind/0.13.2/iai_callgrind/enum.EntryPoint.html

--- a/docs/src/client_requests.md
+++ b/docs/src/client_requests.md
@@ -71,6 +71,8 @@ fn main() {
 # }
 ```
 
+<!-- TODO: Add needed entry point customization -->
+
 This was just a small introduction, please see the
 [`docs`](https://docs.rs/iai-callgrind/0.13.2/iai_callgrind/client_requests) for
 more details!

--- a/docs/src/flamegraphs.md
+++ b/docs/src/flamegraphs.md
@@ -35,6 +35,9 @@ main!(
 # }
 ```
 
+<!-- TODO: Add a flamegraph example svg -->
+<!-- TODO: Talk about the flamegraphs if entry point is custom -->
+
 Callgrind flamegraphs show the inclusive costs for functions and a single
 `EventKind` (default is `EventKind::Ir`), similar to `callgrind_annotate` but in
 a nicer (and clickable) way. Especially, differential flamegraphs facilitate a

--- a/docs/src/flamegraphs.md
+++ b/docs/src/flamegraphs.md
@@ -5,7 +5,7 @@ the `BinaryBenchmarkConfig` or `LibraryBenchmarkConfig`. Callgrind flamegraphs
 are meant as a complement to valgrind's visualization tools
 `callgrind_annotate` and `kcachegrind`.
 
-For example create differential flamegraphs for all benchmarks in a library
+For example create all kind of flamegraphs for all benchmarks in a library
 benchmark:
 
 ```rust
@@ -13,7 +13,7 @@ benchmark:
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    FlamegraphConfig, FlamegraphKind
+    FlamegraphConfig
 };
 use std::hint::black_box;
 
@@ -27,22 +27,33 @@ library_benchmark_group!(name = my_group; benchmarks = bench_library);
 # fn main() {
 main!(
     config = LibraryBenchmarkConfig::default()
-        .flamegraph(FlamegraphConfig::default()
-            .kind(FlamegraphKind::Differential)
-        );
+        .flamegraph(FlamegraphConfig::default());
     library_benchmark_groups = my_group
 );
 # }
 ```
 
-<!-- TODO: Add a flamegraph example svg -->
-<!-- TODO: Talk about the flamegraphs if entry point is custom -->
-
-Callgrind flamegraphs show the inclusive costs for functions and a single
-`EventKind` (default is `EventKind::Ir`), similar to `callgrind_annotate` but in
-a nicer (and clickable) way. Especially, differential flamegraphs facilitate a
-deeper understanding of code sections which cause a bottleneck or a performance
-regressions etc.
-
 The produced flamegraph `*.svg` files are located next to the respective
-callgrind output file in the `target/iai` directory.
+callgrind output file in the `target/iai`
+[directory](./cli_and_env/output/out_directory.md).
+
+## Regular Flamegraphs
+
+Regular callgrind flamegraphs show the inclusive costs for functions and a
+single `EventKind` (default is `EventKind::Ir`), similar to
+`callgrind_annotate`. Suppose the example from above is stored in a benchmark
+`iai_callgrind_benchmark`:
+
+![Regular Flamegraph](./images/flamegraph_regular.svg)
+
+If you open this image in a new tab, you can play around with the svg.
+
+## Differential Flamegraphs
+
+Differential flamegraphs facilitate a deeper understanding of code sections
+which cause a bottleneck or a performance regressions etc.
+
+![Differential Flamegraph](./images/flamegraph_diff.svg)
+
+We simulated a small change in `bubble_sort` and in the differential flamegraph
+you can spot fairly easily where the increase of `Instructions` is happening.

--- a/docs/src/images/flamegraph_diff.svg
+++ b/docs/src/images/flamegraph_diff.svg
@@ -1,0 +1,491 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="562" onload="init(evt)" viewBox="0 0 1200 562" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno"><!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.--><!--NOTES: --><defs><linearGradient id="background" y1="0" y2="1" x1="0" x2="0"><stop stop-color="#eeeeee" offset="5%"/><stop stop-color="#eeeeb0" offset="95%"/></linearGradient></defs><style type="text/css">
+text { font-family:monospace; font-size:12px }
+#title { text-anchor:middle; font-size:17px; }
+#matched { text-anchor:end; }
+#search { text-anchor:end; opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style><script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = true;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]><![CDATA["use strict";
+var details, searchbtn, unzoombtn, matchedtxt, svg, searching, frames, known_font_width;
+function init(evt) {
+    details = document.getElementById("details").firstChild;
+    searchbtn = document.getElementById("search");
+    unzoombtn = document.getElementById("unzoom");
+    matchedtxt = document.getElementById("matched");
+    svg = document.getElementsByTagName("svg")[0];
+    frames = document.getElementById("frames");
+    known_font_width = get_monospace_width(frames);
+    total_samples = parseInt(frames.attributes.total_samples.value);
+    searching = 0;
+
+    // Use GET parameters to restore a flamegraph's state.
+    var restore_state = function() {
+        var params = get_params();
+        if (params.x && params.y)
+            zoom(find_group(document.querySelector('[*|x="' + params.x + '"][y="' + params.y + '"]')));
+        if (params.s)
+            search(params.s);
+    };
+
+    if (fluiddrawing) {
+        // Make width dynamic so the SVG fits its parent's width.
+        svg.removeAttribute("width");
+        // Edge requires us to have a viewBox that gets updated with size changes.
+        var isEdge = /Edge\/\d./i.test(navigator.userAgent);
+        if (!isEdge) {
+            svg.removeAttribute("viewBox");
+        }
+        var update_for_width_change = function() {
+            if (isEdge) {
+                svg.attributes.viewBox.value = "0 0 " + svg.width.baseVal.value + " " + svg.height.baseVal.value;
+            }
+
+            // Keep consistent padding on left and right of frames container.
+            frames.attributes.width.value = svg.width.baseVal.value - xpad * 2;
+
+            // Text truncation needs to be adjusted for the current width.
+            update_text_for_elements(frames.children);
+
+            // Keep search elements at a fixed distance from right edge.
+            var svgWidth = svg.width.baseVal.value;
+            searchbtn.attributes.x.value = svgWidth - xpad;
+            matchedtxt.attributes.x.value = svgWidth - xpad;
+        };
+        window.addEventListener('resize', function() {
+            update_for_width_change();
+        });
+        // This needs to be done asynchronously for Safari to work.
+        setTimeout(function() {
+            unzoom();
+            update_for_width_change();
+            restore_state();
+        }, 0);
+    } else {
+        restore_state();
+    }
+}
+// event listeners
+window.addEventListener("click", function(e) {
+    var target = find_group(e.target);
+    if (target) {
+        if (target.nodeName == "a") {
+            if (e.ctrlKey === false) return;
+            e.preventDefault();
+        }
+        if (target.classList.contains("parent")) unzoom();
+        zoom(target);
+
+        // set parameters for zoom state
+        var el = target.querySelector("rect");
+        if (el && el.attributes && el.attributes.y && el.attributes["fg:x"]) {
+            var params = get_params()
+            params.x = el.attributes["fg:x"].value;
+            params.y = el.attributes.y.value;
+            history.replaceState(null, null, parse_params(params));
+        }
+    }
+    else if (e.target.id == "unzoom") {
+        unzoom();
+
+        // remove zoom state
+        var params = get_params();
+        if (params.x) delete params.x;
+        if (params.y) delete params.y;
+        history.replaceState(null, null, parse_params(params));
+    }
+    else if (e.target.id == "search") search_prompt();
+}, false)
+// mouse-over for info
+// show
+window.addEventListener("mouseover", function(e) {
+    var target = find_group(e.target);
+    if (target) details.nodeValue = nametype + " " + g_to_text(target);
+}, false)
+// clear
+window.addEventListener("mouseout", function(e) {
+    var target = find_group(e.target);
+    if (target) details.nodeValue = ' ';
+}, false)
+// ctrl-F for search
+window.addEventListener("keydown",function (e) {
+    if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+        e.preventDefault();
+        search_prompt();
+    }
+}, false)
+// functions
+function get_params() {
+    var params = {};
+    var paramsarr = window.location.search.substr(1).split('&');
+    for (var i = 0; i < paramsarr.length; ++i) {
+        var tmp = paramsarr[i].split("=");
+        if (!tmp[0] || !tmp[1]) continue;
+        params[tmp[0]]  = decodeURIComponent(tmp[1]);
+    }
+    return params;
+}
+function parse_params(params) {
+    var uri = "?";
+    for (var key in params) {
+        uri += key + '=' + encodeURIComponent(params[key]) + '&';
+    }
+    if (uri.slice(-1) == "&")
+        uri = uri.substring(0, uri.length - 1);
+    if (uri == '?')
+        uri = window.location.href.split('?')[0];
+    return uri;
+}
+function find_child(node, selector) {
+    var children = node.querySelectorAll(selector);
+    if (children.length) return children[0];
+    return;
+}
+function find_group(node) {
+    var parent = node.parentElement;
+    if (!parent) return;
+    if (parent.id == "frames") return node;
+    return find_group(parent);
+}
+function orig_save(e, attr, val) {
+    if (e.attributes["fg:orig_" + attr] != undefined) return;
+    if (e.attributes[attr] == undefined) return;
+    if (val == undefined) val = e.attributes[attr].value;
+    e.setAttribute("fg:orig_" + attr, val);
+}
+function orig_load(e, attr) {
+    if (e.attributes["fg:orig_"+attr] == undefined) return;
+    e.attributes[attr].value = e.attributes["fg:orig_" + attr].value;
+    e.removeAttribute("fg:orig_" + attr);
+}
+function g_to_text(e) {
+    var text = find_child(e, "title").firstChild.nodeValue;
+    return (text)
+}
+function g_to_func(e) {
+    var func = g_to_text(e);
+    // if there's any manipulation we want to do to the function
+    // name before it's searched, do it here before returning.
+    return (func);
+}
+function get_monospace_width(frames) {
+    // Given the id="frames" element, return the width of text characters if
+    // this is a monospace font, otherwise return 0.
+    text = find_child(frames.children[0], "text");
+    originalContent = text.textContent;
+    text.textContent = "!";
+    bangWidth = text.getComputedTextLength();
+    text.textContent = "W";
+    wWidth = text.getComputedTextLength();
+    text.textContent = originalContent;
+    if (bangWidth === wWidth) {
+        return bangWidth;
+    } else {
+        return 0;
+    }
+}
+function update_text_for_elements(elements) {
+    // In order to render quickly in the browser, you want to do one pass of
+    // reading attributes, and one pass of mutating attributes. See
+    // https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/ for details.
+
+    // Fall back to inefficient calculation, if we're variable-width font.
+    // TODO This should be optimized somehow too.
+    if (known_font_width === 0) {
+        for (var i = 0; i < elements.length; i++) {
+            update_text(elements[i]);
+        }
+        return;
+    }
+
+    var textElemNewAttributes = [];
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var r = find_child(e, "rect");
+        var t = find_child(e, "text");
+        var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
+        var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+        var newX = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
+        // Smaller than this size won't fit anything
+        if (w < 2 * known_font_width) {
+            textElemNewAttributes.push([newX, ""]);
+            continue;
+        }
+
+        // Fit in full text width
+        if (txt.length * known_font_width < w) {
+            textElemNewAttributes.push([newX, txt]);
+            continue;
+        }
+
+        var substringLength = Math.floor(w / known_font_width) - 2;
+        if (truncate_text_right) {
+            // Truncate the right side of the text.
+            textElemNewAttributes.push([newX, txt.substring(0, substringLength) + ".."]);
+            continue;
+        } else {
+            // Truncate the left side of the text.
+            textElemNewAttributes.push([newX, ".." + txt.substring(txt.length - substringLength, txt.length)]);
+            continue;
+        }
+    }
+
+    console.assert(textElemNewAttributes.length === elements.length, "Resize failed, please file a bug at https://github.com/jonhoo/inferno/");
+
+    // Now that we know new textContent, set it all in one go so we don't refresh a bazillion times.
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var values = textElemNewAttributes[i];
+        var t = find_child(e, "text");
+        t.attributes.x.value = values[0];
+        t.textContent = values[1];
+    }
+}
+
+function update_text(e) {
+    var r = find_child(e, "rect");
+    var t = find_child(e, "text");
+    var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
+    var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+    t.attributes.x.value = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
+    // Smaller than this size won't fit anything
+    if (w < 2 * fontsize * fontwidth) {
+        t.textContent = "";
+        return;
+    }
+    t.textContent = txt;
+    // Fit in full text width
+    if (t.getComputedTextLength() < w)
+        return;
+    if (truncate_text_right) {
+        // Truncate the right side of the text.
+        for (var x = txt.length - 2; x > 0; x--) {
+            if (t.getSubStringLength(0, x + 2) <= w) {
+                t.textContent = txt.substring(0, x) + "..";
+                return;
+            }
+        }
+    } else {
+        // Truncate the left side of the text.
+        for (var x = 2; x < txt.length; x++) {
+            if (t.getSubStringLength(x - 2, txt.length) <= w) {
+                t.textContent = ".." + txt.substring(x, txt.length);
+                return;
+            }
+        }
+    }
+    t.textContent = "";
+}
+// zoom
+function zoom_reset(e) {
+    if (e.tagName == "rect") {
+        e.attributes.x.value = format_percent(100 * parseInt(e.attributes["fg:x"].value) / total_samples);
+        e.attributes.width.value = format_percent(100 * parseInt(e.attributes["fg:w"].value) / total_samples);
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_reset(c[i]);
+    }
+}
+function zoom_child(e, x, zoomed_width_samples) {
+    if (e.tagName == "text") {
+        var parent_x = parseFloat(find_child(e.parentNode, "rect[x]").attributes.x.value);
+        e.attributes.x.value = format_percent(parent_x + (100 * 3 / frames.attributes.width.value));
+    } else if (e.tagName == "rect") {
+        e.attributes.x.value = format_percent(100 * (parseInt(e.attributes["fg:x"].value) - x) / zoomed_width_samples);
+        e.attributes.width.value = format_percent(100 * parseInt(e.attributes["fg:w"].value) / zoomed_width_samples);
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_child(c[i], x, zoomed_width_samples);
+    }
+}
+function zoom_parent(e) {
+    if (e.attributes) {
+        if (e.attributes.x != undefined) {
+            e.attributes.x.value = "0.0%";
+        }
+        if (e.attributes.width != undefined) {
+            e.attributes.width.value = "100.0%";
+        }
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_parent(c[i]);
+    }
+}
+function zoom(node) {
+    var attr = find_child(node, "rect").attributes;
+    var width = parseInt(attr["fg:w"].value);
+    var xmin = parseInt(attr["fg:x"].value);
+    var xmax = xmin + width;
+    var ymin = parseFloat(attr.y.value);
+    unzoombtn.classList.remove("hide");
+    var el = frames.children;
+    var to_update_text = [];
+    for (var i = 0; i < el.length; i++) {
+        var e = el[i];
+        var a = find_child(e, "rect").attributes;
+        var ex = parseInt(a["fg:x"].value);
+        var ew = parseInt(a["fg:w"].value);
+        // Is it an ancestor
+        if (!inverted) {
+            var upstack = parseFloat(a.y.value) > ymin;
+        } else {
+            var upstack = parseFloat(a.y.value) < ymin;
+        }
+        if (upstack) {
+            // Direct ancestor
+            if (ex <= xmin && (ex+ew) >= xmax) {
+                e.classList.add("parent");
+                zoom_parent(e);
+                to_update_text.push(e);
+            }
+            // not in current path
+            else
+                e.classList.add("hide");
+        }
+        // Children maybe
+        else {
+            // no common path
+            if (ex < xmin || ex >= xmax) {
+                e.classList.add("hide");
+            }
+            else {
+                zoom_child(e, xmin, width);
+                to_update_text.push(e);
+            }
+        }
+    }
+    update_text_for_elements(to_update_text);
+}
+function unzoom() {
+    unzoombtn.classList.add("hide");
+    var el = frames.children;
+    for(var i = 0; i < el.length; i++) {
+        el[i].classList.remove("parent");
+        el[i].classList.remove("hide");
+        zoom_reset(el[i]);
+    }
+    update_text_for_elements(el);
+}
+// search
+function reset_search() {
+    var el = document.querySelectorAll("#frames rect");
+    for (var i = 0; i < el.length; i++) {
+        orig_load(el[i], "fill")
+    }
+    var params = get_params();
+    delete params.s;
+    history.replaceState(null, null, parse_params(params));
+}
+function search_prompt() {
+    if (!searching) {
+        var term = prompt("Enter a search term (regexp " +
+            "allowed, eg: ^ext4_)", "");
+        if (term != null) {
+            search(term)
+        }
+    } else {
+        reset_search();
+        searching = 0;
+        searchbtn.classList.remove("show");
+        searchbtn.firstChild.nodeValue = "Search"
+        matchedtxt.classList.add("hide");
+        matchedtxt.firstChild.nodeValue = ""
+    }
+}
+function search(term) {
+    var re = new RegExp(term);
+    var el = frames.children;
+    var matches = new Object();
+    var maxwidth = 0;
+    for (var i = 0; i < el.length; i++) {
+        var e = el[i];
+        // Skip over frames which are either not visible, or below the zoomed-to frame
+        if (e.classList.contains("hide") || e.classList.contains("parent")) {
+            continue;
+        }
+        var func = g_to_func(e);
+        var rect = find_child(e, "rect");
+        if (func == null || rect == null)
+            continue;
+        // Save max width. Only works as we have a root frame
+        var w = parseInt(rect.attributes["fg:w"].value);
+        if (w > maxwidth)
+            maxwidth = w;
+        if (func.match(re)) {
+            // highlight
+            var x = parseInt(rect.attributes["fg:x"].value);
+            orig_save(rect, "fill");
+            rect.attributes.fill.value = searchcolor;
+            // remember matches
+            if (matches[x] == undefined) {
+                matches[x] = w;
+            } else {
+                if (w > matches[x]) {
+                    // overwrite with parent
+                    matches[x] = w;
+                }
+            }
+            searching = 1;
+        }
+    }
+    if (!searching)
+        return;
+    var params = get_params();
+    params.s = term;
+    history.replaceState(null, null, parse_params(params));
+
+    searchbtn.classList.add("show");
+    searchbtn.firstChild.nodeValue = "Reset Search";
+    // calculate percent matched, excluding vertical overlap
+    var count = 0;
+    var lastx = -1;
+    var lastw = 0;
+    var keys = Array();
+    for (k in matches) {
+        if (matches.hasOwnProperty(k))
+            keys.push(k);
+    }
+    // sort the matched frames by their x location
+    // ascending, then width descending
+    keys.sort(function(a, b){
+        return a - b;
+    });
+    // Step through frames saving only the biggest bottom-up frames
+    // thanks to the sort order. This relies on the tree property
+    // where children are always smaller than their parents.
+    for (var k in keys) {
+        var x = parseInt(keys[k]);
+        var w = matches[keys[k]];
+        if (x >= lastx + lastw) {
+            count += w;
+            lastx = x;
+            lastw = w;
+        }
+    }
+    // display matched percent
+    matchedtxt.classList.remove("hide");
+    var pct = 100 * count / maxwidth;
+    if (pct != 100) pct = pct.toFixed(1);
+    matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+}
+function format_percent(n) {
+    return n.toFixed(4) + "%";
+}
+]]></script><rect x="0" y="0" width="100%" height="562" fill="url(#background)"/><text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">iai_callgrind_benchmark::my_group::bench_library</text><text id="subtitle" x="50.0000%" y="48.00">callgrind.bench_library.flamegraph.Ir.diff.old.svg</text><text id="details" fill="rgb(0,0,0)" x="10" y="64.00"> </text><text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text><text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text><text id="matched" fill="rgb(0,0,0)" x="1190" y="551.00"> </text><svg id="frames" x="10" width="1180" total_samples="454"><g><title>all (454 Instructions, 100%)</title><rect x="0.0000%" y="76" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="86.50"></text></g><g><title>(below main) [/usr/lib/libc.so.6] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="92" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="102.50">(below main) [/usr/lib/libc.so.6]</text></g><g><title>(below main) [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="108" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="118.50">(below main) [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="124" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="134.50">/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="140" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="150.50">/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/core/src/ops/function.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="156" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="166.50">/rustc/90743e72/library/core/src/ops/function.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="172" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="182.50">/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="188" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="198.50">/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/std/src/sys_common/backtrace.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="204" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="214.50">/rustc/90743e72/library/std/src/sys_common/backtrace.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5a..</text></g><g><title>0x000000000001cdc0 [/usr/lib/ld-linux-x86-64.so.2] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="220" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="230.50">0x000000000001cdc0 [/usr/lib/ld-linux-x86-64.so.2]</text></g><g><title>0x0000000000025d90 [/usr/lib/libc.so.6] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="236" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="246.50">0x0000000000025d90 [/usr/lib/libc.so.6]</text></g><g><title>my_lib/benches/test_lib_bench/dev/dev.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="252" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="262.50">my_lib/benches/test_lib_bench/dev/dev.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark..</text></g><g><title>my_lib/benches/test_lib_bench/dev/dev.rs:iai_callgrind_benchmark::bench_library::wrapper [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="268" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="278.50">my_lib/benches/test_lib_bench/dev/dev.rs:iai_callgrind_benchmark::bench_library::wrapper [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>iai-callgrind/src/macros.rs:iai_callgrind_benchmark::main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="284" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="294.50">iai-callgrind/src/macros.rs:iai_callgrind_benchmark::main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>iai-callgrind/src/macros.rs:iai_callgrind_benchmark::my_group::__run [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; 0.00%)</title><rect x="0.0000%" y="300" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="454"/><text x="0.2500%" y="310.50">iai-callgrind/src/macros.rs:iai_callgrind_benchmark::my_group::__run [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (454 Instructions, 100.00%; +0.44%)</title><rect x="0.0000%" y="316" width="100.0000%" height="15" fill="rgb(255,248,248)" fg:x="0" fg:w="454"/><text x="0.2500%" y="326.50">main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>my_lib/src/lib.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (373 Instructions, 82.16%; +59.69%)</title><rect x="17.8414%" y="332" width="82.1586%" height="15" fill="rgb(255,100,100)" fg:x="81" fg:w="373"/><text x="18.0914%" y="342.50">my_lib/src/lib.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/core/src/cmp.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (78 Instructions, 17.18%; +3.30%)</title><rect x="82.8194%" y="348" width="17.1806%" height="15" fill="rgb(255,241,241)" fg:x="376" fg:w="78"/><text x="83.0694%" y="358.50">/rustc/90743e72/library/cor..</text></g><g><title>/rustc/90743e72/library/core/src/intrinsics.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (63 Instructions, 13.88%; +0.66%)</title><rect x="86.1233%" y="364" width="13.8767%" height="15" fill="rgb(255,248,248)" fg:x="391" fg:w="63"/><text x="86.3733%" y="374.50">/rustc/90743e72/libra..</text></g><g><title>/rustc/90743e72/library/alloc/src/alloc.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (60 Instructions, 13.22%; +0.66%)</title><rect x="86.7841%" y="380" width="13.2159%" height="15" fill="rgb(255,248,248)" fg:x="394" fg:w="60"/><text x="87.0341%" y="390.50">/rustc/90743e72/libr..</text></g><g><title>/rustc/90743e72/library/core/src/iter/range.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (57 Instructions, 12.56%; +0.44%)</title><rect x="87.4449%" y="396" width="12.5551%" height="15" fill="rgb(255,248,248)" fg:x="397" fg:w="57"/><text x="87.6949%" y="406.50">/rustc/90743e72/lib..</text></g><g><title>__rust_alloc [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (55 Instructions, 12.11%; +0.22%)</title><rect x="87.8855%" y="412" width="12.1145%" height="15" fill="rgb(255,249,249)" fg:x="399" fg:w="55"/><text x="88.1355%" y="422.50">__rust_alloc [targ..</text></g><g><title>/rustc/90743e72/library/std/src/alloc.rs:__rdl_alloc [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (54 Instructions, 11.89%; +0.44%)</title><rect x="88.1057%" y="428" width="11.8943%" height="15" fill="rgb(255,248,248)" fg:x="400" fg:w="54"/><text x="88.3557%" y="438.50">/rustc/90743e72/li..</text></g><g><title>/rustc/90743e72/library/std/src/sys/unix/alloc.rs:__rdl_alloc [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (52 Instructions, 11.45%; +1.54%)</title><rect x="88.5463%" y="444" width="11.4537%" height="15" fill="rgb(255,246,246)" fg:x="402" fg:w="52"/><text x="88.7963%" y="454.50">/rustc/90743e72/l..</text></g><g><title>malloc [/usr/lib/libc.so.6] (45 Instructions, 9.91%; +0.66%)</title><rect x="90.0881%" y="460" width="9.9119%" height="15" fill="rgb(255,248,248)" fg:x="409" fg:w="45"/><text x="90.3381%" y="470.50">malloc [/usr/l..</text></g><g><title>/rustc/90743e72/library/core/src/slice/index.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (42 Instructions, 9.25%; +8.15%)</title><rect x="90.7489%" y="476" width="9.2511%" height="15" fill="rgb(255,229,229)" fg:x="412" fg:w="42"/><text x="90.9989%" y="486.50">/rustc/90743e..</text></g><g><title>/rustc/90743e72/library/alloc/src/vec/mod.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (5 Instructions, 1.10%; +0.22%)</title><rect x="98.8987%" y="492" width="1.1013%" height="15" fill="rgb(255,249,249)" fg:x="449" fg:w="5"/><text x="99.1487%" y="502.50"></text></g><g><title>/rustc/90743e72/library/core/src/hint.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (4 Instructions, 0.88%; +0.66%)</title><rect x="99.1189%" y="508" width="0.8811%" height="15" fill="rgb(255,248,248)" fg:x="450" fg:w="4"/><text x="99.3689%" y="518.50"></text></g><g><title>/rustc/90743e72/library/alloc/src/vec/mod.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (1 Instructions, 0.22%; +0.22%)</title><rect x="99.7797%" y="524" width="0.2203%" height="15" fill="rgb(255,249,249)" fg:x="453" fg:w="1"/><text x="100.0297%" y="534.50"></text></g></svg></svg>

--- a/docs/src/images/flamegraph_regular.svg
+++ b/docs/src/images/flamegraph_regular.svg
@@ -1,0 +1,491 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="562" onload="init(evt)" viewBox="0 0 1200 562" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno"><!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.--><!--NOTES: --><defs><linearGradient id="background" y1="0" y2="1" x1="0" x2="0"><stop stop-color="#eeeeee" offset="5%"/><stop stop-color="#eeeeb0" offset="95%"/></linearGradient></defs><style type="text/css">
+text { font-family:monospace; font-size:12px }
+#title { text-anchor:middle; font-size:17px; }
+#matched { text-anchor:end; }
+#search { text-anchor:end; opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style><script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = true;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]><![CDATA["use strict";
+var details, searchbtn, unzoombtn, matchedtxt, svg, searching, frames, known_font_width;
+function init(evt) {
+    details = document.getElementById("details").firstChild;
+    searchbtn = document.getElementById("search");
+    unzoombtn = document.getElementById("unzoom");
+    matchedtxt = document.getElementById("matched");
+    svg = document.getElementsByTagName("svg")[0];
+    frames = document.getElementById("frames");
+    known_font_width = get_monospace_width(frames);
+    total_samples = parseInt(frames.attributes.total_samples.value);
+    searching = 0;
+
+    // Use GET parameters to restore a flamegraph's state.
+    var restore_state = function() {
+        var params = get_params();
+        if (params.x && params.y)
+            zoom(find_group(document.querySelector('[*|x="' + params.x + '"][y="' + params.y + '"]')));
+        if (params.s)
+            search(params.s);
+    };
+
+    if (fluiddrawing) {
+        // Make width dynamic so the SVG fits its parent's width.
+        svg.removeAttribute("width");
+        // Edge requires us to have a viewBox that gets updated with size changes.
+        var isEdge = /Edge\/\d./i.test(navigator.userAgent);
+        if (!isEdge) {
+            svg.removeAttribute("viewBox");
+        }
+        var update_for_width_change = function() {
+            if (isEdge) {
+                svg.attributes.viewBox.value = "0 0 " + svg.width.baseVal.value + " " + svg.height.baseVal.value;
+            }
+
+            // Keep consistent padding on left and right of frames container.
+            frames.attributes.width.value = svg.width.baseVal.value - xpad * 2;
+
+            // Text truncation needs to be adjusted for the current width.
+            update_text_for_elements(frames.children);
+
+            // Keep search elements at a fixed distance from right edge.
+            var svgWidth = svg.width.baseVal.value;
+            searchbtn.attributes.x.value = svgWidth - xpad;
+            matchedtxt.attributes.x.value = svgWidth - xpad;
+        };
+        window.addEventListener('resize', function() {
+            update_for_width_change();
+        });
+        // This needs to be done asynchronously for Safari to work.
+        setTimeout(function() {
+            unzoom();
+            update_for_width_change();
+            restore_state();
+        }, 0);
+    } else {
+        restore_state();
+    }
+}
+// event listeners
+window.addEventListener("click", function(e) {
+    var target = find_group(e.target);
+    if (target) {
+        if (target.nodeName == "a") {
+            if (e.ctrlKey === false) return;
+            e.preventDefault();
+        }
+        if (target.classList.contains("parent")) unzoom();
+        zoom(target);
+
+        // set parameters for zoom state
+        var el = target.querySelector("rect");
+        if (el && el.attributes && el.attributes.y && el.attributes["fg:x"]) {
+            var params = get_params()
+            params.x = el.attributes["fg:x"].value;
+            params.y = el.attributes.y.value;
+            history.replaceState(null, null, parse_params(params));
+        }
+    }
+    else if (e.target.id == "unzoom") {
+        unzoom();
+
+        // remove zoom state
+        var params = get_params();
+        if (params.x) delete params.x;
+        if (params.y) delete params.y;
+        history.replaceState(null, null, parse_params(params));
+    }
+    else if (e.target.id == "search") search_prompt();
+}, false)
+// mouse-over for info
+// show
+window.addEventListener("mouseover", function(e) {
+    var target = find_group(e.target);
+    if (target) details.nodeValue = nametype + " " + g_to_text(target);
+}, false)
+// clear
+window.addEventListener("mouseout", function(e) {
+    var target = find_group(e.target);
+    if (target) details.nodeValue = ' ';
+}, false)
+// ctrl-F for search
+window.addEventListener("keydown",function (e) {
+    if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+        e.preventDefault();
+        search_prompt();
+    }
+}, false)
+// functions
+function get_params() {
+    var params = {};
+    var paramsarr = window.location.search.substr(1).split('&');
+    for (var i = 0; i < paramsarr.length; ++i) {
+        var tmp = paramsarr[i].split("=");
+        if (!tmp[0] || !tmp[1]) continue;
+        params[tmp[0]]  = decodeURIComponent(tmp[1]);
+    }
+    return params;
+}
+function parse_params(params) {
+    var uri = "?";
+    for (var key in params) {
+        uri += key + '=' + encodeURIComponent(params[key]) + '&';
+    }
+    if (uri.slice(-1) == "&")
+        uri = uri.substring(0, uri.length - 1);
+    if (uri == '?')
+        uri = window.location.href.split('?')[0];
+    return uri;
+}
+function find_child(node, selector) {
+    var children = node.querySelectorAll(selector);
+    if (children.length) return children[0];
+    return;
+}
+function find_group(node) {
+    var parent = node.parentElement;
+    if (!parent) return;
+    if (parent.id == "frames") return node;
+    return find_group(parent);
+}
+function orig_save(e, attr, val) {
+    if (e.attributes["fg:orig_" + attr] != undefined) return;
+    if (e.attributes[attr] == undefined) return;
+    if (val == undefined) val = e.attributes[attr].value;
+    e.setAttribute("fg:orig_" + attr, val);
+}
+function orig_load(e, attr) {
+    if (e.attributes["fg:orig_"+attr] == undefined) return;
+    e.attributes[attr].value = e.attributes["fg:orig_" + attr].value;
+    e.removeAttribute("fg:orig_" + attr);
+}
+function g_to_text(e) {
+    var text = find_child(e, "title").firstChild.nodeValue;
+    return (text)
+}
+function g_to_func(e) {
+    var func = g_to_text(e);
+    // if there's any manipulation we want to do to the function
+    // name before it's searched, do it here before returning.
+    return (func);
+}
+function get_monospace_width(frames) {
+    // Given the id="frames" element, return the width of text characters if
+    // this is a monospace font, otherwise return 0.
+    text = find_child(frames.children[0], "text");
+    originalContent = text.textContent;
+    text.textContent = "!";
+    bangWidth = text.getComputedTextLength();
+    text.textContent = "W";
+    wWidth = text.getComputedTextLength();
+    text.textContent = originalContent;
+    if (bangWidth === wWidth) {
+        return bangWidth;
+    } else {
+        return 0;
+    }
+}
+function update_text_for_elements(elements) {
+    // In order to render quickly in the browser, you want to do one pass of
+    // reading attributes, and one pass of mutating attributes. See
+    // https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/ for details.
+
+    // Fall back to inefficient calculation, if we're variable-width font.
+    // TODO This should be optimized somehow too.
+    if (known_font_width === 0) {
+        for (var i = 0; i < elements.length; i++) {
+            update_text(elements[i]);
+        }
+        return;
+    }
+
+    var textElemNewAttributes = [];
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var r = find_child(e, "rect");
+        var t = find_child(e, "text");
+        var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
+        var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+        var newX = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
+        // Smaller than this size won't fit anything
+        if (w < 2 * known_font_width) {
+            textElemNewAttributes.push([newX, ""]);
+            continue;
+        }
+
+        // Fit in full text width
+        if (txt.length * known_font_width < w) {
+            textElemNewAttributes.push([newX, txt]);
+            continue;
+        }
+
+        var substringLength = Math.floor(w / known_font_width) - 2;
+        if (truncate_text_right) {
+            // Truncate the right side of the text.
+            textElemNewAttributes.push([newX, txt.substring(0, substringLength) + ".."]);
+            continue;
+        } else {
+            // Truncate the left side of the text.
+            textElemNewAttributes.push([newX, ".." + txt.substring(txt.length - substringLength, txt.length)]);
+            continue;
+        }
+    }
+
+    console.assert(textElemNewAttributes.length === elements.length, "Resize failed, please file a bug at https://github.com/jonhoo/inferno/");
+
+    // Now that we know new textContent, set it all in one go so we don't refresh a bazillion times.
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var values = textElemNewAttributes[i];
+        var t = find_child(e, "text");
+        t.attributes.x.value = values[0];
+        t.textContent = values[1];
+    }
+}
+
+function update_text(e) {
+    var r = find_child(e, "rect");
+    var t = find_child(e, "text");
+    var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
+    var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+    t.attributes.x.value = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
+    // Smaller than this size won't fit anything
+    if (w < 2 * fontsize * fontwidth) {
+        t.textContent = "";
+        return;
+    }
+    t.textContent = txt;
+    // Fit in full text width
+    if (t.getComputedTextLength() < w)
+        return;
+    if (truncate_text_right) {
+        // Truncate the right side of the text.
+        for (var x = txt.length - 2; x > 0; x--) {
+            if (t.getSubStringLength(0, x + 2) <= w) {
+                t.textContent = txt.substring(0, x) + "..";
+                return;
+            }
+        }
+    } else {
+        // Truncate the left side of the text.
+        for (var x = 2; x < txt.length; x++) {
+            if (t.getSubStringLength(x - 2, txt.length) <= w) {
+                t.textContent = ".." + txt.substring(x, txt.length);
+                return;
+            }
+        }
+    }
+    t.textContent = "";
+}
+// zoom
+function zoom_reset(e) {
+    if (e.tagName == "rect") {
+        e.attributes.x.value = format_percent(100 * parseInt(e.attributes["fg:x"].value) / total_samples);
+        e.attributes.width.value = format_percent(100 * parseInt(e.attributes["fg:w"].value) / total_samples);
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_reset(c[i]);
+    }
+}
+function zoom_child(e, x, zoomed_width_samples) {
+    if (e.tagName == "text") {
+        var parent_x = parseFloat(find_child(e.parentNode, "rect[x]").attributes.x.value);
+        e.attributes.x.value = format_percent(parent_x + (100 * 3 / frames.attributes.width.value));
+    } else if (e.tagName == "rect") {
+        e.attributes.x.value = format_percent(100 * (parseInt(e.attributes["fg:x"].value) - x) / zoomed_width_samples);
+        e.attributes.width.value = format_percent(100 * parseInt(e.attributes["fg:w"].value) / zoomed_width_samples);
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_child(c[i], x, zoomed_width_samples);
+    }
+}
+function zoom_parent(e) {
+    if (e.attributes) {
+        if (e.attributes.x != undefined) {
+            e.attributes.x.value = "0.0%";
+        }
+        if (e.attributes.width != undefined) {
+            e.attributes.width.value = "100.0%";
+        }
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_parent(c[i]);
+    }
+}
+function zoom(node) {
+    var attr = find_child(node, "rect").attributes;
+    var width = parseInt(attr["fg:w"].value);
+    var xmin = parseInt(attr["fg:x"].value);
+    var xmax = xmin + width;
+    var ymin = parseFloat(attr.y.value);
+    unzoombtn.classList.remove("hide");
+    var el = frames.children;
+    var to_update_text = [];
+    for (var i = 0; i < el.length; i++) {
+        var e = el[i];
+        var a = find_child(e, "rect").attributes;
+        var ex = parseInt(a["fg:x"].value);
+        var ew = parseInt(a["fg:w"].value);
+        // Is it an ancestor
+        if (!inverted) {
+            var upstack = parseFloat(a.y.value) > ymin;
+        } else {
+            var upstack = parseFloat(a.y.value) < ymin;
+        }
+        if (upstack) {
+            // Direct ancestor
+            if (ex <= xmin && (ex+ew) >= xmax) {
+                e.classList.add("parent");
+                zoom_parent(e);
+                to_update_text.push(e);
+            }
+            // not in current path
+            else
+                e.classList.add("hide");
+        }
+        // Children maybe
+        else {
+            // no common path
+            if (ex < xmin || ex >= xmax) {
+                e.classList.add("hide");
+            }
+            else {
+                zoom_child(e, xmin, width);
+                to_update_text.push(e);
+            }
+        }
+    }
+    update_text_for_elements(to_update_text);
+}
+function unzoom() {
+    unzoombtn.classList.add("hide");
+    var el = frames.children;
+    for(var i = 0; i < el.length; i++) {
+        el[i].classList.remove("parent");
+        el[i].classList.remove("hide");
+        zoom_reset(el[i]);
+    }
+    update_text_for_elements(el);
+}
+// search
+function reset_search() {
+    var el = document.querySelectorAll("#frames rect");
+    for (var i = 0; i < el.length; i++) {
+        orig_load(el[i], "fill")
+    }
+    var params = get_params();
+    delete params.s;
+    history.replaceState(null, null, parse_params(params));
+}
+function search_prompt() {
+    if (!searching) {
+        var term = prompt("Enter a search term (regexp " +
+            "allowed, eg: ^ext4_)", "");
+        if (term != null) {
+            search(term)
+        }
+    } else {
+        reset_search();
+        searching = 0;
+        searchbtn.classList.remove("show");
+        searchbtn.firstChild.nodeValue = "Search"
+        matchedtxt.classList.add("hide");
+        matchedtxt.firstChild.nodeValue = ""
+    }
+}
+function search(term) {
+    var re = new RegExp(term);
+    var el = frames.children;
+    var matches = new Object();
+    var maxwidth = 0;
+    for (var i = 0; i < el.length; i++) {
+        var e = el[i];
+        // Skip over frames which are either not visible, or below the zoomed-to frame
+        if (e.classList.contains("hide") || e.classList.contains("parent")) {
+            continue;
+        }
+        var func = g_to_func(e);
+        var rect = find_child(e, "rect");
+        if (func == null || rect == null)
+            continue;
+        // Save max width. Only works as we have a root frame
+        var w = parseInt(rect.attributes["fg:w"].value);
+        if (w > maxwidth)
+            maxwidth = w;
+        if (func.match(re)) {
+            // highlight
+            var x = parseInt(rect.attributes["fg:x"].value);
+            orig_save(rect, "fill");
+            rect.attributes.fill.value = searchcolor;
+            // remember matches
+            if (matches[x] == undefined) {
+                matches[x] = w;
+            } else {
+                if (w > matches[x]) {
+                    // overwrite with parent
+                    matches[x] = w;
+                }
+            }
+            searching = 1;
+        }
+    }
+    if (!searching)
+        return;
+    var params = get_params();
+    params.s = term;
+    history.replaceState(null, null, parse_params(params));
+
+    searchbtn.classList.add("show");
+    searchbtn.firstChild.nodeValue = "Reset Search";
+    // calculate percent matched, excluding vertical overlap
+    var count = 0;
+    var lastx = -1;
+    var lastw = 0;
+    var keys = Array();
+    for (k in matches) {
+        if (matches.hasOwnProperty(k))
+            keys.push(k);
+    }
+    // sort the matched frames by their x location
+    // ascending, then width descending
+    keys.sort(function(a, b){
+        return a - b;
+    });
+    // Step through frames saving only the biggest bottom-up frames
+    // thanks to the sort order. This relies on the tree property
+    // where children are always smaller than their parents.
+    for (var k in keys) {
+        var x = parseInt(keys[k]);
+        var w = matches[keys[k]];
+        if (x >= lastx + lastw) {
+            count += w;
+            lastx = x;
+            lastw = w;
+        }
+    }
+    // display matched percent
+    matchedtxt.classList.remove("hide");
+    var pct = 100 * count / maxwidth;
+    if (pct != 100) pct = pct.toFixed(1);
+    matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+}
+function format_percent(n) {
+    return n.toFixed(4) + "%";
+}
+]]></script><rect x="0" y="0" width="100%" height="562" fill="url(#background)"/><text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">iai_callgrind_benchmark::my_group::bench_library</text><text id="subtitle" x="50.0000%" y="48.00">callgrind.bench_library.flamegraph.Ir.svg</text><text id="details" fill="rgb(0,0,0)" x="10" y="64.00"> </text><text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text><text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text><text id="matched" fill="rgb(0,0,0)" x="1190" y="551.00"> </text><svg id="frames" x="10" width="1180" total_samples="164"><g><title>all (164 Instructions, 100%)</title><rect x="0.0000%" y="76" width="100.0000%" height="15" fill="rgb(227,0,7)" fg:x="0" fg:w="164"/><text x="0.2500%" y="86.50"></text></g><g><title>(below main) [/usr/lib/libc.so.6] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="92" width="100.0000%" height="15" fill="rgb(217,0,24)" fg:x="0" fg:w="164"/><text x="0.2500%" y="102.50">(below main) [/usr/lib/libc.so.6]</text></g><g><title>(below main) [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="108" width="100.0000%" height="15" fill="rgb(221,193,54)" fg:x="0" fg:w="164"/><text x="0.2500%" y="118.50">(below main) [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="124" width="100.0000%" height="15" fill="rgb(248,212,6)" fg:x="0" fg:w="164"/><text x="0.2500%" y="134.50">/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="140" width="100.0000%" height="15" fill="rgb(208,68,35)" fg:x="0" fg:w="164"/><text x="0.2500%" y="150.50">/rustc/90743e72/library/core/src/ops/function.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/core/src/ops/function.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="156" width="100.0000%" height="15" fill="rgb(232,128,0)" fg:x="0" fg:w="164"/><text x="0.2500%" y="166.50">/rustc/90743e72/library/core/src/ops/function.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="172" width="100.0000%" height="15" fill="rgb(207,160,47)" fg:x="0" fg:w="164"/><text x="0.2500%" y="182.50">/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start::{{closure}} [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="188" width="100.0000%" height="15" fill="rgb(228,23,34)" fg:x="0" fg:w="164"/><text x="0.2500%" y="198.50">/rustc/90743e72/library/std/src/rt.rs:std::rt::lang_start_internal [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>/rustc/90743e72/library/std/src/sys_common/backtrace.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="204" width="100.0000%" height="15" fill="rgb(218,30,26)" fg:x="0" fg:w="164"/><text x="0.2500%" y="214.50">/rustc/90743e72/library/std/src/sys_common/backtrace.rs:std::sys_common::backtrace::__rust_begin_short_backtrace [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5a..</text></g><g><title>0x000000000001cdc0 [/usr/lib/ld-linux-x86-64.so.2] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="220" width="100.0000%" height="15" fill="rgb(220,122,19)" fg:x="0" fg:w="164"/><text x="0.2500%" y="230.50">0x000000000001cdc0 [/usr/lib/ld-linux-x86-64.so.2]</text></g><g><title>0x0000000000025d90 [/usr/lib/libc.so.6] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="236" width="100.0000%" height="15" fill="rgb(250,228,42)" fg:x="0" fg:w="164"/><text x="0.2500%" y="246.50">0x0000000000025d90 [/usr/lib/libc.so.6]</text></g><g><title>my_lib/benches/test_lib_bench/dev/iai_callgrind_benchmark.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="252" width="100.0000%" height="15" fill="rgb(240,193,28)" fg:x="0" fg:w="164"/><text x="0.2500%" y="262.50">my_lib/benches/test_lib_bench/dev/iai_callgrind_benchmark.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark..</text></g><g><title>my_lib/benches/test_lib_bench/dev/iai_callgrind_benchmark.rs:iai_callgrind_benchmark::bench_library::wrapper [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="268" width="100.0000%" height="15" fill="rgb(216,20,37)" fg:x="0" fg:w="164"/><text x="0.2500%" y="278.50">my_lib/benches/test_lib_bench/dev/iai_callgrind_benchmark.rs:iai_callgrind_benchmark::bench_library::wrapper [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>iai-callgrind/src/macros.rs:iai_callgrind_benchmark::main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="284" width="100.0000%" height="15" fill="rgb(206,188,39)" fg:x="0" fg:w="164"/><text x="0.2500%" y="294.50">iai-callgrind/src/macros.rs:iai_callgrind_benchmark::main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>iai-callgrind/src/macros.rs:iai_callgrind_benchmark::my_group::__run [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="300" width="100.0000%" height="15" fill="rgb(217,207,13)" fg:x="0" fg:w="164"/><text x="0.2500%" y="310.50">iai-callgrind/src/macros.rs:iai_callgrind_benchmark::my_group::__run [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (164 Instructions, 100.00%)</title><rect x="0.0000%" y="316" width="100.0000%" height="15" fill="rgb(231,73,38)" fg:x="0" fg:w="164"/><text x="0.2500%" y="326.50">main [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe]</text></g><g><title>my_lib/src/lib.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (85 Instructions, 51.83%)</title><rect x="48.1707%" y="332" width="51.8293%" height="15" fill="rgb(225,20,46)" fg:x="79" fg:w="85"/><text x="48.4207%" y="342.50">my_lib/src/lib.rs:benchmark_tests::bubble_sort [target/release/deps/test_lib..</text></g><g><title>/rustc/90743e72/library/alloc/src/alloc.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (61 Instructions, 37.20%)</title><rect x="62.8049%" y="348" width="37.1951%" height="15" fill="rgb(210,31,41)" fg:x="103" fg:w="61"/><text x="63.0549%" y="358.50">/rustc/90743e72/library/alloc/src/alloc.rs:iai_callgrind_benchmark..</text></g><g><title>__rust_alloc [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (55 Instructions, 33.54%)</title><rect x="66.4634%" y="364" width="33.5366%" height="15" fill="rgb(221,200,47)" fg:x="109" fg:w="55"/><text x="66.7134%" y="374.50">__rust_alloc [target/release/deps/iai_callgrind_benchmark-0..</text></g><g><title>/rustc/90743e72/library/std/src/alloc.rs:__rdl_alloc [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (54 Instructions, 32.93%)</title><rect x="67.0732%" y="380" width="32.9268%" height="15" fill="rgb(226,26,5)" fg:x="110" fg:w="54"/><text x="67.3232%" y="390.50">/rustc/90743e72/library/std/src/alloc.rs:__rdl_alloc ..</text></g><g><title>/rustc/90743e72/library/std/src/sys/unix/alloc.rs:__rdl_alloc [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (52 Instructions, 31.71%)</title><rect x="68.2927%" y="396" width="31.7073%" height="15" fill="rgb(249,33,26)" fg:x="112" fg:w="52"/><text x="68.5427%" y="406.50">/rustc/90743e72/library/std/src/sys/unix/alloc.rs:_..</text></g><g><title>malloc [/usr/lib/libc.so.6] (45 Instructions, 27.44%)</title><rect x="72.5610%" y="412" width="27.4390%" height="15" fill="rgb(235,183,28)" fg:x="119" fg:w="45"/><text x="72.8110%" y="422.50">malloc [/usr/lib/libc.so.6]</text></g><g><title>/rustc/90743e72/library/core/src/iter/range.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (19 Instructions, 11.59%)</title><rect x="88.4146%" y="428" width="11.5854%" height="15" fill="rgb(221,5,38)" fg:x="145" fg:w="19"/><text x="88.6646%" y="438.50">/rustc/90743e72/l..</text></g><g><title>/rustc/90743e72/library/core/src/cmp.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (16 Instructions, 9.76%)</title><rect x="90.2439%" y="444" width="9.7561%" height="15" fill="rgb(247,18,42)" fg:x="148" fg:w="16"/><text x="90.4939%" y="454.50">/rustc/90743e7..</text></g><g><title>/rustc/90743e72/library/core/src/intrinsics.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (9 Instructions, 5.49%)</title><rect x="94.5122%" y="460" width="5.4878%" height="15" fill="rgb(241,131,45)" fg:x="155" fg:w="9"/><text x="94.7622%" y="470.50">/rustc/..</text></g><g><title>/rustc/90743e72/library/core/src/slice/index.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (6 Instructions, 3.66%)</title><rect x="96.3415%" y="476" width="3.6585%" height="15" fill="rgb(249,31,29)" fg:x="158" fg:w="6"/><text x="96.5915%" y="486.50">/rus..</text></g><g><title>/rustc/90743e72/library/alloc/src/vec/mod.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (5 Instructions, 3.05%)</title><rect x="96.9512%" y="492" width="3.0488%" height="15" fill="rgb(225,111,53)" fg:x="159" fg:w="5"/><text x="97.2012%" y="502.50">/ru..</text></g><g><title>/rustc/90743e72/library/core/src/hint.rs:iai_callgrind_benchmark::bench_library::__iai_callgrind_wrapper_mod::bench_library [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (4 Instructions, 2.44%)</title><rect x="97.5610%" y="508" width="2.4390%" height="15" fill="rgb(238,160,17)" fg:x="160" fg:w="4"/><text x="97.8110%" y="518.50">/r..</text></g><g><title>/rustc/90743e72/library/alloc/src/vec/mod.rs:benchmark_tests::bubble_sort [target/release/deps/iai_callgrind_benchmark-0ec7db6ec42f5afe] (1 Instructions, 0.61%)</title><rect x="99.3902%" y="524" width="0.6098%" height="15" fill="rgb(214,148,48)" fg:x="163" fg:w="1"/><text x="99.6402%" y="534.50"></text></g></svg></svg>

--- a/iai-callgrind-runner/src/api.rs
+++ b/iai-callgrind-runner/src/api.rs
@@ -89,11 +89,17 @@ pub enum Direction {
     BottomToTop,
 }
 
+/// The `EntryPoint` of a library benchmark
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum EntryPoint {
+    /// Disable the entry point and default toggle entirely
     None,
+    /// The default entry point is the benchmark function
     #[default]
     Default,
+    /// A custom entry point. The argument allows the same glob patterns as the
+    /// [`--toggle-collect`](https://valgrind.org/docs/manual/cl-manual.html#cl-manual.options)
+    /// argument of callgrind.
     Custom(String),
 }
 

--- a/iai-callgrind-runner/src/runner/callgrind/hashmap_parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/hashmap_parser.rs
@@ -37,8 +37,7 @@ struct CurrentId {
 
 /// Parse a callgrind outfile into a `HashMap`
 ///
-/// This parser is a based on `callgrind_annotate` and how the summarize the function inclusive
-/// costs.
+/// This parser is a based on `callgrind_annotate` and how `it` summarizes the inclusive costs.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HashMapParser {
     pub sentinel: Option<Sentinel>,

--- a/iai-callgrind-runner/src/runner/callgrind/hashmap_parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/hashmap_parser.rs
@@ -129,6 +129,9 @@ impl Parser for HashMapParser {
         let mut cfn_totals = HashMap::<Id, Value>::new();
         let mut fn_totals = HashMap::<Id, Value>::new();
 
+        // FIXME: This should be a vec. The sentinel can match many functions. This is only ok,
+        // since we currently use the sentinel for the benchmark function exclusively. The benchmark
+        // function is very special in that it is called exactly once, is not recursive etc.
         let mut sentinel_key = None;
 
         // We start within he header

--- a/iai-callgrind-runner/src/runner/callgrind/sentinel_parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/sentinel_parser.rs
@@ -46,6 +46,7 @@ impl Parser for SentinelParser {
         let properties = parse_header(&mut iter)
             .map_err(|error| Error::ParseError((output_path.to_path(), error.to_string())))?;
 
+        let mut found = false;
         let mut costs = properties.costs_prototype;
         let mut start_record = false;
 
@@ -62,6 +63,7 @@ impl Parser for SentinelParser {
                             trace!("Found line with sentinel: '{}'", line);
                             start_record = true;
                         }
+                        found = true;
                     }
                 }
                 continue;
@@ -85,20 +87,17 @@ impl Parser for SentinelParser {
             }
         }
 
-        Ok(costs)
-
-        // TODO: CLEANUP
-        // if found {
-        //     Ok(costs)
-        // } else {
-        //     Err(Error::ParseError((
-        //         output_path.to_path(),
-        //         format!(
-        //             "Sentinel '{}' not found.{}",
-        //             &self.sentinel, ERROR_MESSAGE_DEBUG_SYMBOLS
-        //         ),
-        //     ))
-        //     .into())
-        // }
+        if found {
+            Ok(costs)
+        } else {
+            Err(Error::ParseError((
+                output_path.to_path(),
+                format!(
+                    "Sentinel '{}' not found.{}",
+                    &self.sentinel, ERROR_MESSAGE_DEBUG_SYMBOLS
+                ),
+            ))
+            .into())
+        }
     }
 }

--- a/iai-callgrind-runner/src/runner/callgrind/sentinel_parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/sentinel_parser.rs
@@ -13,6 +13,11 @@ Please make sure you have debug symbols enabled in your benchmark profile.
 See also the Installation section in the iai-callgrind README:
 https://github.com/iai-callgrind/iai-callgrind?tab=readme-ov-file#installation";
 
+/// A parser for callgrind output files which collects all costs for a [`Sentinel`].
+///
+/// This parser is limited to `Sentinels` which can occur only once per callgrind output file and
+/// are not recursive. This includes the Sentinel created from the
+/// [`crate::runner::DEFAULT_TOGGLE`].
 pub struct SentinelParser {
     sentinel: Sentinel,
 }
@@ -41,7 +46,6 @@ impl Parser for SentinelParser {
         let properties = parse_header(&mut iter)
             .map_err(|error| Error::ParseError((output_path.to_path(), error.to_string())))?;
 
-        let mut found = false;
         let mut costs = properties.costs_prototype;
         let mut start_record = false;
 
@@ -58,7 +62,6 @@ impl Parser for SentinelParser {
                             trace!("Found line with sentinel: '{}'", line);
                             start_record = true;
                         }
-                        found = true;
                     }
                 }
                 continue;
@@ -82,17 +85,20 @@ impl Parser for SentinelParser {
             }
         }
 
-        if found {
-            Ok(costs)
-        } else {
-            Err(Error::ParseError((
-                output_path.to_path(),
-                format!(
-                    "Sentinel '{}' not found.{}",
-                    &self.sentinel, ERROR_MESSAGE_DEBUG_SYMBOLS
-                ),
-            ))
-            .into())
-        }
+        Ok(costs)
+
+        // TODO: CLEANUP
+        // if found {
+        //     Ok(costs)
+        // } else {
+        //     Err(Error::ParseError((
+        //         output_path.to_path(),
+        //         format!(
+        //             "Sentinel '{}' not found.{}",
+        //             &self.sentinel, ERROR_MESSAGE_DEBUG_SYMBOLS
+        //         ),
+        //     ))
+        //     .into())
+        // }
     }
 }

--- a/iai-callgrind-runner/src/runner/format.rs
+++ b/iai-callgrind-runner/src/runner/format.rs
@@ -672,6 +672,8 @@ mod tests {
         #[case] diff_pct: &str,
         #[case] diff_fact: Option<&str>,
     ) {
+        colored::control::set_override(false);
+
         let new_costs = Costs(indexmap! {event_kind => new});
         let old_costs = old.map(|old| Costs(indexmap! {event_kind => old}));
         let costs_summary = CostsSummary::new(&new_costs, old_costs.as_ref());

--- a/iai-callgrind-runner/src/runner/meta.rs
+++ b/iai-callgrind-runner/src/runner/meta.rs
@@ -23,6 +23,13 @@ pub struct Cmd {
 pub struct Metadata {
     pub arch: String,
     pub project_root: PathBuf,
+    /// The absolute path of the `HOME` (per default `$WORKSPACE_ROOT/target/iai`). Plus, if
+    /// configured, the target of the host like `x86_64-linux-unknown-gnu`. The final component is
+    /// the `CARGO_PKG_NAME`.
+    ///
+    /// Examples:
+    /// * `/home/my/workspace/my-project/target/iai/my-project` or
+    /// * `/home/my/workspace/my-project/target/iai/x86_64-linux-unknown-gnu/my-project`
     pub target_dir: PathBuf,
     pub valgrind: Cmd,
     pub valgrind_wrapper: Option<Cmd>,

--- a/iai-callgrind-runner/src/runner/mod.rs
+++ b/iai-callgrind-runner/src/runner/mod.rs
@@ -6,7 +6,7 @@ pub mod costs;
 pub mod dhat;
 mod format;
 mod lib_bench;
-mod meta;
+pub mod meta;
 pub mod summary;
 pub mod tool;
 

--- a/iai-callgrind-runner/src/runner/tool/mod.rs
+++ b/iai-callgrind-runner/src/runner/tool/mod.rs
@@ -67,6 +67,7 @@ pub struct ToolOutputPath {
     pub kind: ToolOutputPathKind,
     pub tool: ValgrindTool,
     pub baseline_kind: BaselineKind,
+    /// The final directory of all the output files
     pub dir: PathBuf,
     pub name: String,
     pub modifiers: Vec<String>,
@@ -527,6 +528,9 @@ impl ToolOutput {
 }
 
 impl ToolOutputPath {
+    /// Create a new `ToolOutputPath`.
+    ///
+    /// The `base_dir` is supposed to be the same as [`Metadata::target_dir`].
     pub fn new(
         kind: ToolOutputPathKind,
         tool: ValgrindTool,

--- a/iai-callgrind-runner/src/runner/tool/mod.rs
+++ b/iai-callgrind-runner/src/runner/tool/mod.rs
@@ -530,7 +530,7 @@ impl ToolOutput {
 impl ToolOutputPath {
     /// Create a new `ToolOutputPath`.
     ///
-    /// The `base_dir` is supposed to be the same as [`Metadata::target_dir`].
+    /// The `base_dir` is supposed to be the same as [`crate::runner::meta::Metadata::target_dir`].
     pub fn new(
         kind: ToolOutputPathKind,
         tool: ValgrindTool,

--- a/iai-callgrind-runner/tests/fixtures/callgrind.out/callgrind.no_entry_point.cmd
+++ b/iai-callgrind-runner/tests/fixtures/callgrind.out/callgrind.no_entry_point.cmd
@@ -4,6 +4,9 @@ cd $(dirname ${BASH_SOURCE[0]}) || exit 1
 
 callgrind_annotate --threshold=100 --inclusive=yes callgrind.no_entry_point.out |\
     ../../../../scripts/callgrind_annotate_to_stacks.pl \
+        --sentinel=0x000000000001b530 \
+        --insert='0 (below main) [/usr/lib/libc.so.6] 103210' \
+        --modify='(below main) [target/release/benchmark-tests-exit] 103222' \
         --modify='0x0000000000005040 [/usr/lib/ld-linux-x86-64.so.2] 806' \
         --insert='0 0x0000000000005040 [/usr/lib/libgcc_s.so.1] 5' \
         --add-missing-ob='target/release/benchmark-tests-exit' \

--- a/iai-callgrind/src/lib.rs
+++ b/iai-callgrind/src/lib.rs
@@ -418,7 +418,7 @@ pub use cty;
 pub use iai_callgrind_macros::{binary_benchmark, library_benchmark};
 #[cfg(feature = "default")]
 pub use iai_callgrind_runner::api::{
-    Direction, EventKind, FlamegraphKind, Pipe, Stdin, Stdio, ValgrindTool,
+    Direction, EntryPoint, EventKind, FlamegraphKind, Pipe, Stdin, Stdio, ValgrindTool,
 };
 #[cfg(feature = "default")]
 pub use lib_bench::LibraryBenchmarkConfig;

--- a/iai-callgrind/src/lib_bench.rs
+++ b/iai-callgrind/src/lib_bench.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use derive_more::AsRef;
 use iai_callgrind_macros::IntoInner;
 
-use crate::internal;
+use crate::{internal, EntryPoint};
 
 /// The main configuration of a library benchmark.
 ///
@@ -64,6 +64,7 @@ impl LibraryBenchmarkConfig {
             tools: internal::InternalTools::default(),
             tools_override: Option::default(),
             truncate_description: Option::default(),
+            entry_point: Option::default(),
         })
     }
 
@@ -564,6 +565,15 @@ impl LibraryBenchmarkConfig {
     /// ```
     pub fn truncate_description(&mut self, value: Option<usize>) -> &mut Self {
         self.0.truncate_description = Some(value);
+        self
+    }
+
+    /// TODO: DOCS
+    pub fn entry_point<T>(&mut self, entry_point: T) -> &mut Self
+    where
+        T: Into<EntryPoint>,
+    {
+        self.0.entry_point = Some(entry_point.into());
         self
     }
 }

--- a/iai-callgrind/src/lib_bench.rs
+++ b/iai-callgrind/src/lib_bench.rs
@@ -617,7 +617,6 @@ impl LibraryBenchmarkConfig {
     /// main!(library_benchmark_groups = some_group);
     /// # }
     /// ```
-    /// 
     /// In the example above [`EntryPoint::Default`] is active, so the counting of events starts
     /// when the `some_bench` function is entered. In `to_be_benchmarked`, the client request
     /// `start_instrumentation` does effectively nothing and `stop_instrumentation` will stop the
@@ -651,7 +650,6 @@ impl LibraryBenchmarkConfig {
     /// # main!(library_benchmark_groups = some_group);
     /// # }
     /// ```
-    /// 
     /// [`--toggle-collect`]: https://valgrind.org/docs/manual/cl-manual.html#cl-manual.options
     pub fn entry_point<T>(&mut self, entry_point: T) -> &mut Self
     where

--- a/iai-callgrind/src/lib_bench.rs
+++ b/iai-callgrind/src/lib_bench.rs
@@ -588,8 +588,8 @@ impl LibraryBenchmarkConfig {
     /// If you're using callgrind client requests either in the benchmark function itself or in your
     /// library, then using [`EntryPoint::None`] is presumably be required. Consider the following
     /// example (`DEFAULT_ENTRY_POINT` marks the default entry point):
-    ///
-    /// ```rust
+    #[cfg_attr(not(feature = "client_requests_defs"), doc = "```rust,ignore")]
+    #[cfg_attr(feature = "client_requests_defs", doc = "```rust")]
     /// use iai_callgrind::{
     ///     main, LibraryBenchmarkConfig,library_benchmark, library_benchmark_group
     /// };
@@ -617,7 +617,7 @@ impl LibraryBenchmarkConfig {
     /// main!(library_benchmark_groups = some_group);
     /// # }
     /// ```
-    ///
+    /// 
     /// In the example above [`EntryPoint::Default`] is active, so the counting of events starts
     /// when the `some_bench` function is entered. In `to_be_benchmarked`, the client request
     /// `start_instrumentation` does effectively nothing and `stop_instrumentation` will stop the
@@ -626,7 +626,6 @@ impl LibraryBenchmarkConfig {
     /// which removes the default toggle, but also `--collect-at-start=no`. So, you need to specify
     /// `--collect-at-start=no` in [`LibraryBenchmarkConfig::raw_callgrind_args`]. The example would
     /// then look like this:
-    ///
     /// ```rust
     /// use std::hint::black_box;
     ///
@@ -652,7 +651,7 @@ impl LibraryBenchmarkConfig {
     /// # main!(library_benchmark_groups = some_group);
     /// # }
     /// ```
-    ///
+    /// 
     /// [`--toggle-collect`]: https://valgrind.org/docs/manual/cl-manual.html#cl-manual.options
     pub fn entry_point<T>(&mut self, entry_point: T) -> &mut Self
     where


### PR DESCRIPTION
This pr adds the possibility to adjust the default toggle which Iai-Callgrind sets automatically in library benchmarks to the module path of the benchmark function. This new option therefore only affects library benchmarks.

There are cases in which this default toggle is just in the way, so it can also be switched off entirely.

Switching off the default toggle with `EntryPoint::None` helps especially when callgrind client requests are used. It is required to switch off the toggle and set `--collect-at-start=no` manually, so the instrumentation starts exactly where the client requests are called. Although not implemented (#255) yet, it will help to benchmark multithreaded/-process applications, since the default toggle needs to be switched off in such cases.

Setting a custom toggle with `EntryPoint::Custom(...)` is convenience for switching off the toggle and setting the `--toggle-collect` manually.