### PR TITLE
Fix: group teardown in library benchmarks is not run when setup is not present

### DIFF
--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.1
@@ -25,4 +25,22 @@ test_lib_bench_main_and_group_setup_and_teardown::check_group::check_file_not_ex
   RAM Hits:                        |N/A             (*********)
   Total read+write:                |N/A             (*********)
   Estimated Cycles:                |N/A             (*********)
+GROUP SETUP
+test_lib_bench_main_and_group_setup_and_teardown::group_only_setup::delete_file_bench
+- end of stdout/stderr
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_file_bench
+- end of stdout/stderr
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+GROUP TEARDOWN
 MAIN TEARDOWN

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.2
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.2
@@ -28,4 +28,24 @@ test_lib_bench_main_and_group_setup_and_teardown::check_group::check_file_not_ex
   RAM Hits:                        |N/A             (*********)
   Total read+write:                |N/A             (*********)
   Estimated Cycles:                |N/A             (*********)
+GROUP SETUP
+test_lib_bench_main_and_group_setup_and_teardown::group_only_setup::delete_file_bench
+- end of stdout/stderr
+  Baselines:                default|default
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_file_bench
+- end of stdout/stderr
+  Baselines:                default|default
+  Instructions:                    |N/A             (*********)
+  L1 Hits:                         |N/A             (*********)
+  L2 Hits:                         |N/A             (*********)
+  RAM Hits:                        |N/A             (*********)
+  Total read+write:                |N/A             (*********)
+  Estimated Cycles:                |N/A             (*********)
+GROUP TEARDOWN
 MAIN TEARDOWN

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.3
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.3
@@ -22,3 +22,19 @@ test_lib_bench_main_and_group_setup_and_teardown::check_group::check_file_not_ex
   RAM Hits:                        |                (         )
   Total read+write:                |                (No change)
   Estimated Cycles:                |                (         )
+test_lib_bench_main_and_group_setup_and_teardown::group_only_setup::delete_file_bench
+  Baselines:                default|default
+  Instructions:                    |                (No change)
+  L1 Hits:                         |                (No change)
+  L2 Hits:                         |                (         )
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (No change)
+  Estimated Cycles:                |                (         )
+test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_file_bench
+  Baselines:                default|default
+  Instructions:                    |                (No change)
+  L1 Hits:                         |                (No change)
+  L2 Hits:                         |                (         )
+  RAM Hits:                        |                (         )
+  Total read+write:                |                (No change)
+  Estimated Cycles:                |                (         )

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.conf.yml
@@ -1,11 +1,14 @@
 groups:
   - runs:
+      # A normal benchmark run
       - args: ["--nocapture"]
         expected:
           stdout: expected_stdout.1
+      # --save-baseline should run all setup and teardown functions as usual
       - args: ["--nocapture", "--save-baseline"]
         expected:
           stdout: expected_stdout.2
+      # --load-baseline should not run any setup and teardown functions
       - args: ["--nocapture", "--load-baseline", "--baseline"]
         expected:
           stdout: expected_stdout.3

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.rs
@@ -47,6 +47,28 @@ library_benchmark_group!(
     benchmarks = simple_bench, check_file_exists
 );
 
+#[library_benchmark]
+fn create_file_bench() {
+    std::fs::write(GROUP_SETUP_FILE, "content").unwrap();
+}
+
+library_benchmark_group!(
+    name = group_only_teardown;
+    teardown = group_teardown();
+    benchmarks = create_file_bench
+);
+
+#[library_benchmark]
+fn delete_file_bench() {
+    std::fs::remove_file(GROUP_SETUP_FILE).unwrap();
+}
+
+library_benchmark_group!(
+    name = group_only_setup;
+    setup = group_setup();
+    benchmarks = delete_file_bench
+);
+
 library_benchmark_group!(
     name = check_group;
     benchmarks = check_file_not_exists
@@ -64,5 +86,6 @@ main!(
     setup = main_setup();
     teardown = main_teardown();
     library_benchmark_groups = simple_group_with_setup,
-    check_group
+    check_group,
+    group_only_teardown
 );

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.rs
@@ -15,17 +15,6 @@ fn simple_bench() {
     assert_eq!(expected, actual);
 }
 
-fn group_setup() {
-    println!("GROUP SETUP");
-    let mut file = File::create(GROUP_SETUP_FILE).unwrap();
-    write!(file, "simple_group_with_setup: {GROUP_SETUP_FILE}").unwrap();
-}
-
-fn group_teardown() {
-    println!("GROUP TEARDOWN");
-    std::fs::remove_file(GROUP_SETUP_FILE).unwrap();
-}
-
 #[library_benchmark]
 fn check_file_exists() {
     if !PathBuf::from(GROUP_SETUP_FILE).exists() {
@@ -40,6 +29,27 @@ fn check_file_not_exists() {
     }
 }
 
+#[library_benchmark]
+fn create_file_bench() {
+    std::fs::write(GROUP_SETUP_FILE, "content").unwrap();
+}
+
+#[library_benchmark]
+fn delete_file_bench() {
+    std::fs::remove_file(GROUP_SETUP_FILE).unwrap();
+}
+
+fn group_setup() {
+    println!("GROUP SETUP");
+    let mut file = File::create(GROUP_SETUP_FILE).unwrap();
+    write!(file, "simple_group_with_setup: {GROUP_SETUP_FILE}").unwrap();
+}
+
+fn group_teardown() {
+    println!("GROUP TEARDOWN");
+    std::fs::remove_file(GROUP_SETUP_FILE).unwrap();
+}
+
 library_benchmark_group!(
     name = simple_group_with_setup;
     setup = group_setup();
@@ -47,21 +57,11 @@ library_benchmark_group!(
     benchmarks = simple_bench, check_file_exists
 );
 
-#[library_benchmark]
-fn create_file_bench() {
-    std::fs::write(GROUP_SETUP_FILE, "content").unwrap();
-}
-
+// No setup and teardown
 library_benchmark_group!(
-    name = group_only_teardown;
-    teardown = group_teardown();
-    benchmarks = create_file_bench
+    name = check_group;
+    benchmarks = check_file_not_exists
 );
-
-#[library_benchmark]
-fn delete_file_bench() {
-    std::fs::remove_file(GROUP_SETUP_FILE).unwrap();
-}
 
 library_benchmark_group!(
     name = group_only_setup;
@@ -70,8 +70,9 @@ library_benchmark_group!(
 );
 
 library_benchmark_group!(
-    name = check_group;
-    benchmarks = check_file_not_exists
+    name = group_only_teardown;
+    teardown = group_teardown();
+    benchmarks = create_file_bench
 );
 
 fn main_setup() {
@@ -86,6 +87,9 @@ main!(
     setup = main_setup();
     teardown = main_teardown();
     library_benchmark_groups = simple_group_with_setup,
+    // Check group is supposed to run directory after `simple_group_with_setup`
     check_group,
+    // The groups below can be run in any order
+    group_only_setup,
     group_only_teardown
 );

--- a/iai-callgrind-runner/src/runner/lib_bench.rs
+++ b/iai-callgrind-runner/src/runner/lib_bench.rs
@@ -281,7 +281,7 @@ impl Groups {
                     ));
             let teardown =
                 library_benchmark_group
-                    .has_setup
+                    .has_teardown
                     .then_some(Assistant::new_group_assistant(
                         AssistantKind::Teardown,
                         &library_benchmark_group.id,


### PR DESCRIPTION
The teardown function in

```rust
library_benchmark_group!(name = my_group; teardown = some_func(); benchmarks = ...)
```

was not executed since the setup was not present, too.

This pr fixes it to the expected behaviour that a `library_benchmark_group!` teardown function is executed independently of the setup.