### PR TITLE
Chore: Verify in benchmark-tests that not all costs are zero, ...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
 name = "benchmark-tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cargo_metadata",
  "colored",
  "glob",

--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -22,6 +22,7 @@ colored = { workspace = true }
 glob = { workspace = true }
 iai-callgrind = { path = "../iai-callgrind", features = ["client_requests"] }
 # Needed in the `cargo bench` wrapper
+anyhow = { workspace = true }
 iai-callgrind-runner = { path = "../iai-callgrind-runner" }
 lazy_static = { workspace = true }
 minijinja = { workspace = true }

--- a/benchmark-tests/src/assert.rs
+++ b/benchmark-tests/src/assert.rs
@@ -1,0 +1,114 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use iai_callgrind_runner::runner::callgrind::hashmap_parser::{CallgrindMap, HashMapParser};
+use iai_callgrind_runner::runner::common::ModulePath;
+use iai_callgrind_runner::runner::summary::{BaselineKind, BenchmarkSummary};
+use iai_callgrind_runner::runner::tool::{self, Parser, ToolOutputPath};
+
+use crate::common::Summary;
+
+#[allow(unused)]
+pub struct Assert {
+    module_path: ModulePath,
+    group: String,
+    function: String,
+    id: String,
+    workspace_root: PathBuf,
+    target_dir: PathBuf,
+    out_dir: PathBuf,
+    out_path: PathBuf,
+    summary_path: Option<PathBuf>,
+}
+
+impl Assert {
+    pub fn new(module_path: &str, group: &str, function: &str, id: &str) -> Result<Self> {
+        let name = format!("{function}.{id}");
+        let package = env!("CARGO_PKG_NAME");
+
+        let meta = cargo_metadata::MetadataCommand::new().exec()?;
+        let target_dir = meta
+            .workspace_root
+            .join("target/iai")
+            .join(package)
+            .into_std_path_buf();
+
+        let out_dir = target_dir.join(module_path).join(group).join(&name);
+
+        let out_path = out_dir.join(format!("callgrind.{name}.out"));
+
+        if !out_path.exists() {
+            panic!(
+                "Callgrind output file '{}' should exist",
+                out_path.display()
+            );
+        }
+
+        let summary_path = out_dir.join("summary.json");
+
+        Ok(Self {
+            module_path: ModulePath::new(module_path),
+            group: group.to_owned(),
+            function: function.to_owned(),
+            id: id.to_owned(),
+            workspace_root: meta.workspace_root.into_std_path_buf(),
+            target_dir,
+            out_dir,
+            out_path,
+            summary_path: summary_path.exists().then_some(summary_path),
+        })
+    }
+
+    /// Asserts that `assert` returns true and panics if it returns false
+    ///
+    /// `assert` takes the deserialized json from the`summary.json` as input and returns a boolean.
+    /// The input is the [`iai_callgrind_runner::runner::summary::BenchmarkSummary`] struct.
+    ///
+    /// # Errors
+    ///
+    /// If the summary.json file did not exist
+    #[track_caller]
+    pub fn summary(&self, assert: fn(BenchmarkSummary) -> bool) -> Result<()> {
+        let summary = Summary::new(
+            self.summary_path
+                .as_ref()
+                .ok_or_else(|| anyhow!("The summary.json should exist"))?,
+        )?;
+
+        assert!(assert(summary.0));
+
+        Ok(())
+    }
+
+    /// Asserts that `assert` returns true and panics if it returns false
+    ///
+    /// The `assert` closure can make assertions based on the
+    /// [`iai_callgrind_runner::runner::callgrind::hashmap_parser::CallgrindMap`]. The assert
+    /// function is supposed to return a boolean.
+    ///
+    /// # Errors
+    ///
+    /// If the summary.json file did not exist
+    #[track_caller]
+    pub fn callgrind_map(&self, assert: fn(CallgrindMap) -> bool) -> Result<()> {
+        let parser = HashMapParser {
+            project_root: self.workspace_root.clone(),
+            sentinel: None,
+        };
+
+        let map = parser
+            .parse(&ToolOutputPath::new(
+                tool::ToolOutputPathKind::Out,
+                tool::ValgrindTool::Callgrind,
+                &BaselineKind::Old,
+                &self.target_dir,
+                &self.module_path.join(&self.group),
+                &format!("{}.{}", self.function, self.id),
+            ))
+            .unwrap();
+
+        assert!(assert(map));
+
+        Ok(())
+    }
+}

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -452,26 +452,22 @@ impl BenchmarkOutput {
 
     fn assert_exit(&self, exit_code: Option<i32>) {
         match exit_code {
-            Some(expected) => {
-                print_info("Verifying exit code");
-                match self.0.status.code() {
-                    Some(code) => {
-                        assert_eq!(
-                            expected, code,
-                            "Expected benchmark to exit with code '{expected}' but exited with \
-                             code '{code}'"
-                        );
-                        print_info(format!(
-                            "Verifying exit code was successful: Process exited with '{code}'"
-                        ));
-                    }
-                    None => panic!(
-                        "Expected benchmark to exit with code '{expected}' but exited with signal \
-                         '{}'",
-                        self.0.status.signal().unwrap()
-                    ),
+            Some(expected) => match self.0.status.code() {
+                Some(code) => {
+                    assert_eq!(
+                        expected, code,
+                        "Expected benchmark to exit with code '{expected}' but exited with code \
+                         '{code}'"
+                    );
+                    print_info(format!(
+                        "Verifying exit code was successful: Process exited with '{code}'"
+                    ));
                 }
-            }
+                None => panic!(
+                    "Expected benchmark to exit with code '{expected}' but exited with signal '{}'",
+                    self.0.status.signal().unwrap()
+                ),
+            },
             None => assert!(
                 self.0.status.success(),
                 "Expected benchmark to exit with success"
@@ -698,8 +694,8 @@ impl RunConfig {
             .map(Result::unwrap)
         {
             let summary = Summary::new(&path).unwrap();
-            summary.assert_not_zero();
-            print_info("Verifying costs are not zero successful");
+            summary.assert_costs_not_all_zero();
+            print_info("Verifying costs not all zero successful");
         }
     }
 }

--- a/benchmark-tests/src/common.rs
+++ b/benchmark-tests/src/common.rs
@@ -15,16 +15,32 @@ impl Summary {
             .map_err(|error| anyhow!(error))
     }
 
+    pub fn get_name(&self) -> String {
+        if let Some(id) = self.0.id.as_ref() {
+            format!("{} {id}", self.0.module_path)
+        } else {
+            self.0.module_path.to_string()
+        }
+    }
+
     #[track_caller]
-    pub fn assert_not_zero(&self) {
+    pub fn assert_costs_not_all_zero(&self) {
         if let Some(callgrind_summary) = &self.0.callgrind_summary {
             for summary in &callgrind_summary.summaries {
                 let (new_costs, old_costs) = summary.events.extract_costs();
                 if let Some(new_costs) = new_costs {
-                    assert!(!new_costs.0.iter().all(|(_, c)| *c == 0));
+                    assert!(
+                        !new_costs.0.iter().all(|(_, c)| *c == 0),
+                        "All *new* costs were zero for '{}'",
+                        self.get_name()
+                    );
                 }
                 if let Some(old_costs) = old_costs {
-                    assert!(!old_costs.0.iter().all(|(_, c)| *c == 0));
+                    assert!(
+                        !old_costs.0.iter().all(|(_, c)| *c == 0),
+                        "All *old* costs were zero for '{}'",
+                        self.get_name()
+                    );
                 }
             }
         }

--- a/benchmark-tests/src/common.rs
+++ b/benchmark-tests/src/common.rs
@@ -1,0 +1,32 @@
+use std::fs::File;
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use iai_callgrind_runner::runner::summary::BenchmarkSummary;
+
+#[derive(Debug)]
+pub struct Summary(pub BenchmarkSummary);
+
+impl Summary {
+    pub fn new(path: &Path) -> Result<Self> {
+        let file = File::open(path)?;
+        serde_json::from_reader(file)
+            .map(Self)
+            .map_err(|error| anyhow!(error))
+    }
+
+    #[track_caller]
+    pub fn assert_not_zero(&self) {
+        if let Some(callgrind_summary) = &self.0.callgrind_summary {
+            for summary in &callgrind_summary.summaries {
+                let (new_costs, old_costs) = summary.events.extract_costs();
+                if let Some(new_costs) = new_costs {
+                    assert!(!new_costs.0.iter().all(|(_, c)| *c == 0));
+                }
+                if let Some(old_costs) = old_costs {
+                    assert!(!old_costs.0.iter().all(|(_, c)| *c == 0));
+                }
+            }
+        }
+    }
+}

--- a/benchmark-tests/src/lib.rs
+++ b/benchmark-tests/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod assert;
+pub mod common;
 pub mod serde_rust_version;
 
 use std::ffi::OsStr;


### PR DESCRIPTION
This pr is used to check whether all costs in a benchmark test are zero. If all costs are zero, this indicates a more severe problem. This change would cause the benchmark test from #252 to fail without the fix it applies.

Additionally, it adds a basic assertion mechanism for more complex assertions needed in #254.