### PR TITLE
chore(deps): Migrate from unmaintained proc-macro-error to proc-macro-error2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cdd32837fa2e86ec09c8266e5aad92400ac934c6dbca83d54673b298db3e45"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.76",
+ "syn",
  "which 4.4.2",
 ]
 
@@ -355,7 +355,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -447,7 +447,7 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -620,7 +620,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -750,13 +750,13 @@ version = "0.4.0"
 dependencies = [
  "derive_more",
  "pretty_assertions",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "rstest",
  "serde",
  "serde_json",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1167,31 +1167,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "74cdd32837fa2e86ec09c8266e5aad92400ac934c6dbca83d54673b298db3e45"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn",
 ]
 
 [[package]]
@@ -1329,7 +1327,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.76",
+ "syn",
  "unicode-ident",
 ]
 
@@ -1424,7 +1422,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -1465,7 +1463,7 @@ checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -1476,7 +1474,7 @@ checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -1536,7 +1534,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -1597,17 +1595,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.76",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -1666,7 +1654,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -1833,7 +1821,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1855,7 +1843,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2080,5 +2068,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ minijinja = { version = "2.0.1" }
 once_cell = { version = "1" }
 predicates = { version = "3" }
 pretty_assertions = "1.1"
-proc-macro-error = "1"
+proc-macro-error2 = "2"
 proc-macro2 = "1.0.63"
 quote = "1.0.28"
 regex = { version = "1.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ minijinja = { version = "2.0.1" }
 once_cell = { version = "1" }
 predicates = { version = "3" }
 pretty_assertions = "1.1"
-proc-macro-error2 = "2"
+proc-macro-error2 = "2.0.1"
 proc-macro2 = "1.0.63"
 quote = "1.0.28"
 regex = { version = "1.9" }

--- a/client-request-tests/tests/fixtures/memcheck-reqs-test.armv7.stderr
+++ b/client-request-tests/tests/fixtures/memcheck-reqs-test.armv7.stderr
@@ -31,6 +31,9 @@ First value of leaked memory: <__NUMBER__>
 Searching for pointers to <__NUMBER__> not-freed blocks
 Checked <__FILTER__> bytes
 
+<__NUMBER__> (<__NUMBER__>) bytes in <__NUMBER__> (<__NUMBER__>) blocks are definitely lost in new loss record <__NUMBER__> of <__NUMBER__>
+<__BACKTRACE__>
+
 LEAK SUMMARY:
 definitely lost: <__FILTER__> bytes in <__FILTER__> blocks
 indirectly lost: <__FILTER__> bytes in <__FILTER__> blocks

--- a/iai-callgrind-macros/Cargo.toml
+++ b/iai-callgrind-macros/Cargo.toml
@@ -20,7 +20,7 @@ derive_more = { workspace = true, default-features = false, features = [
   "deref",
   "deref_mut",
 ] }
-proc-macro-error = { workspace = true }
+proc-macro-error2 = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 serde = { workspace = true }

--- a/iai-callgrind-macros/src/bin_bench.rs
+++ b/iai-callgrind-macros/src/bin_bench.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 
 use derive_more::{Deref, DerefMut};
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::Parse;
 use syn::punctuated::Punctuated;

--- a/iai-callgrind-macros/src/common.rs
+++ b/iai-callgrind-macros/src/common.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::{abort, emit_error};
+use proc_macro_error2::{abort, emit_error};
 use quote::{format_ident, quote, quote_spanned, ToTokens, TokenStreamExt};
 use syn::parse::Parse;
 use syn::spanned::Spanned;

--- a/iai-callgrind-macros/src/derive_macros.rs
+++ b/iai-callgrind-macros/src/derive_macros.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::quote;
 use syn::parse2;
 

--- a/iai-callgrind-macros/src/lib.rs
+++ b/iai-callgrind-macros/src/lib.rs
@@ -31,7 +31,7 @@ mod derive_macros;
 mod lib_bench;
 
 use proc_macro::TokenStream;
-use proc_macro_error::proc_macro_error;
+use proc_macro_error2::proc_macro_error;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]

--- a/iai-callgrind-macros/src/lib_bench.rs
+++ b/iai-callgrind-macros/src/lib_bench.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use derive_more::{Deref, DerefMut};
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 use syn::parse::Parse;
 use syn::punctuated::Punctuated;


### PR DESCRIPTION
Migrate to [proc-macro-error2]() since [proc-macro-error](https://crates.io/crates/proc-macro-error) is unmaintained (see https://rustsec.org/advisories/RUSTSEC-2024-0370) and uses `syn v1` instead of `syn v2`. Using `syn v1` causes most likely duplicate dependencies as described in #262.

There's a bug in https://github.com/GnomedDev/proc-macro-error-2/pull/2 that needs to be fixed before this pr can be merged.

Closes #78 
Closes #262 