### PR TITLE
tests: Add benchmark test which runs all callgrind command-line arguments

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -59,6 +59,7 @@ binstall
 bools
 bumpversion
 cachesim
+cacheuse
 cachuse
 callgrind
 cicd
@@ -103,6 +104,7 @@ gnueabi
 gnueabihf
 grcov
 hljs
+hwpref
 ildmr
 ilmr
 ilog

--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -248,6 +248,11 @@ path = "benches/test_lib_bench/output_format/test_lib_bench_output_format.rs"
 
 [[bench]]
 harness = false
+name = "test_lib_bench_all_args"
+path = "benches/test_lib_bench/all_args/test_lib_bench_all_args.rs"
+
+[[bench]]
+harness = false
 name = "lib_bench_threads"
 path = "benches/guide/lib_bench_threads.rs"
 

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stderr.1a
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stderr.1a
@@ -1,0 +1,6 @@
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-strings=yes'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-pos=yes'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--combine-dumps=yes'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-strings=no'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-pos=no'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--combine-dumps=no'

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stderr.1b
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stderr.1b
@@ -1,0 +1,6 @@
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-strings=yes'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-pos=yes'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--combine-dumps=yes'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-strings=no'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--compress-pos=no'
+iai_callgrind_runner::runner::callgrind::args: Warn : Ignoring callgrind argument: '--combine-dumps=no'

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1a
@@ -1,0 +1,186 @@
+test_lib_bench_all_args::my_group::bench_library dump_creation_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library dump_creation_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library activity_options
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library data_collection_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  SysCount:                                |N/A                  (*********)
+  SysTime:                                 |N/A                  (*********)
+  SysCpuTime:                              |N/A                  (*********)
+  Ge:                                      |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_callers_1
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_callers_func_1
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_recs_3
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_recs_func_3
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library skip_plt_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library skip_plt_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library fn_skip
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library simulation_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  Bc:                                      |N/A                  (*********)
+  Bcm:                                     |N/A                  (*********)
+  Bi:                                      |N/A                  (*********)
+  Bim:                                     |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library simulation_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  AcCost1:                                 |N/A                  (*********)
+  AcCost2:                                 |N/A                  (*********)
+  SpLoss1:                                 |N/A                  (*********)
+  SpLoss2:                                 |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_sizes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_with_client_request data_collection_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_yes
+Number of primes found in the range 0 to 20000: 2262
+- end of stdout/stderr
+  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  Command: <__COMMAND__>
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  Command: <__COMMAND__>
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  Command: <__COMMAND__>
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  ## Total
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_no
+Number of primes found in the range 0 to 20000: 2262
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1b
@@ -1,0 +1,186 @@
+test_lib_bench_all_args::my_group::bench_library dump_creation_options_yes
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library dump_creation_options_no
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library activity_options
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library data_collection_options_yes
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+  SysCount:                                |                     (No change)
+  SysTime:                                 |                     (         )
+  SysCpuTime:                              |                     (         )
+  Ge:                                      |                     (No change)
+test_lib_bench_all_args::my_group::bench_library separate_callers_1
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library separate_callers_func_1
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library separate_recs_3
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library separate_recs_func_3
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library skip_plt_yes
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library skip_plt_no
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library fn_skip
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library simulation_options_yes
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+  Bc:                                      |                     (No change)
+  Bcm:                                     |                     (No change)
+  Bi:                                      |                     (No change)
+  Bim:                                     |                     (No change)
+test_lib_bench_all_args::my_group::bench_library simulation_options_no
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_yes
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+  AcCost1:                                 |                     (No change)
+  AcCost2:                                 |                     (No change)
+  SpLoss1:                                 |                     (No change)
+  SpLoss2:                                 |                     (No change)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_no
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_sizes
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_with_client_request data_collection_options_no
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_yes
+Number of primes found in the range 0 to 20000: 2262
+- end of stdout/stderr
+  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  Command: <__COMMAND__>
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  Command: <__COMMAND__>
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  Command: <__COMMAND__>
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+  ## Total
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_no
+Number of primes found in the range 0 to 20000: 2262
+- end of stdout/stderr
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  L2 Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.freebsd.1a
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.freebsd.1a
@@ -1,0 +1,185 @@
+test_lib_bench_all_args::my_group::bench_library dump_creation_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library dump_creation_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library activity_options
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library data_collection_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  SysCount:                                |N/A                  (*********)
+  SysTime:                                 |N/A                  (*********)
+  Ge:                                      |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_callers_1
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_callers_func_1
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_recs_3
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library separate_recs_func_3
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library skip_plt_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library skip_plt_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library fn_skip
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library simulation_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  Bc:                                      |N/A                  (*********)
+  Bcm:                                     |N/A                  (*********)
+  Bi:                                      |N/A                  (*********)
+  Bim:                                     |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library simulation_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_yes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  AcCost1:                                 |N/A                  (*********)
+  AcCost2:                                 |N/A                  (*********)
+  SpLoss1:                                 |N/A                  (*********)
+  SpLoss2:                                 |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_library cache_simulation_options_sizes
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_with_client_request data_collection_options_no
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_yes
+Number of primes found in the range 0 to 20000: 2262
+- end of stdout/stderr
+  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  Command: <__COMMAND__>
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  Command: <__COMMAND__>
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  Command: <__COMMAND__>
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  ## Total
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_no
+Number of primes found in the range 0 to 20000: 2262
+- end of stdout/stderr
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/all_args/test_lib_bench_all_args.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/all_args/test_lib_bench_all_args.conf.yml
@@ -1,0 +1,27 @@
+# In this test all callgrind arguments as of valgrind v3.23 are used.
+#
+# The actual functionality of these arguments is tested only basically since
+# callgrind is responsible for the functionality. However, the test verifies if
+# any of these arguments cause unexpected behaviour in Iai-Callgrind itself like
+# panics or errors. We also verify that all additional event kinds like Ge,
+# AcLoss etc. are recorded and printed.
+groups:
+  - runs_on: "!x86_64-unknown-freebsd"
+    runs:
+      - args: ["--nocapture"]
+        expected:
+          zero_callgrind_metrics: true
+          stdout: expected_stdout.1a
+          stderr: expected_stderr.1a
+      - args: ["--nocapture"]
+        expected:
+          zero_callgrind_metrics: true
+          stdout: expected_stdout.1b
+          stderr: expected_stderr.1b
+  - runs_on: "x86_64-unknown-freebsd"
+    runs:
+      - args: ["--nocapture"]
+        expected:
+          zero_callgrind_metrics: true
+          stdout: expected_stdout.freebsd.1a
+          stderr: expected_stderr.1a

--- a/benchmark-tests/benches/test_lib_bench/all_args/test_lib_bench_all_args.rs
+++ b/benchmark-tests/benches/test_lib_bench/all_args/test_lib_bench_all_args.rs
@@ -1,0 +1,203 @@
+use std::hint::black_box;
+
+use iai_callgrind::{
+    library_benchmark, library_benchmark_group, main, EntryPoint, LibraryBenchmarkConfig,
+    OutputFormat,
+};
+
+#[cfg(any(target_vendor = "apple", target_os = "freebsd"))]
+pub fn get_data_collections_options_yes() -> LibraryBenchmarkConfig {
+    LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "instr-atstart=yes",
+            "collect-atstart=yes",
+            "toggle-collect=benchmark_tests::fibonacci",
+            "collect-jumps=yes",
+            "collect-systime=yes",
+            "collect-bus=yes",
+        ])
+        .clone()
+}
+
+#[cfg(not(any(target_vendor = "apple", target_os = "freebsd")))]
+pub fn get_data_collections_options_yes() -> LibraryBenchmarkConfig {
+    LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "instr-atstart=yes",
+            "collect-atstart=yes",
+            "toggle-collect=benchmark_tests::fibonacci",
+            "collect-jumps=yes",
+            "collect-systime=nsec",
+            "collect-bus=yes",
+        ])
+        .clone()
+}
+
+#[library_benchmark]
+#[bench::dump_creation_options_yes(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "dump-line=yes",
+            "dump-instr=yes",
+            "compress-strings=yes",
+            "compress-pos=yes",
+            "combine-dumps=yes"
+        ])
+)]
+#[bench::dump_creation_options_no(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "dump-line=no",
+            "dump-instr=no",
+            "compress-strings=no",
+            "compress-pos=no",
+            "combine-dumps=no"
+        ])
+)]
+#[bench::activity_options(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "dump-every-bb=10000",
+            "dump-before=benchmark_tests::fibonacci",
+            "zero-before=benchmark_tests::fibonacci",
+            "dump-after=benchmark_tests::fibonacci"
+        ])
+)]
+#[bench::data_collection_options_yes(
+    config = get_data_collections_options_yes()
+)]
+#[bench::separate_callers_1(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "separate-callers=1",
+        ])
+)]
+#[bench::separate_callers_func_1(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "separate-callers1=benchmark_tests::fibonacci",
+        ])
+)]
+#[bench::separate_recs_3(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "separate-recs=3",
+        ])
+)]
+#[bench::separate_recs_func_3(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "separate-recs3=benchmark_tests::fibonacci",
+        ])
+)]
+#[bench::skip_plt_yes(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "skip-plt=yes",
+        ])
+)]
+#[bench::skip_plt_no(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "skip-plt=no",
+        ])
+)]
+#[bench::fn_skip(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "fn-skip=benchmark_tests::fibonacci",
+        ])
+)]
+#[bench::simulation_options_yes(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "cache-sim=yes",
+            "branch-sim=yes",
+        ])
+)]
+#[bench::simulation_options_no(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "cache-sim=no",
+            "branch-sim=no",
+        ])
+)]
+#[bench::cache_simulation_options_yes(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "cache-sim=yes",
+            "simulate-wb=yes",
+            "simulate-hwpref=yes",
+            "cacheuse=yes",
+        ])
+)]
+#[bench::cache_simulation_options_no(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "cache-sim=yes",
+            "simulate-wb=no",
+            "simulate-hwpref=no",
+            "cacheuse=no",
+        ])
+)]
+#[bench::cache_simulation_options_sizes(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "cache-sim=yes",
+            "I1=65536,16,128",
+            "D1=65536,16,128",
+            "LL=67108864,32,128",
+        ])
+)]
+fn bench_library() -> u64 {
+    black_box(benchmark_tests::fibonacci(10))
+}
+
+#[library_benchmark]
+#[bench::data_collection_options_no(
+    config = LibraryBenchmarkConfig::default()
+        .entry_point(EntryPoint::None)
+        .callgrind_args([
+            "instr-atstart=no",
+            "collect-atstart=no",
+            "collect-jumps=no",
+            "collect-systime=no",
+            "collect-bus=no",
+        ])
+)]
+fn bench_with_client_request() -> u64 {
+    iai_callgrind::client_requests::callgrind::start_instrumentation();
+    iai_callgrind::client_requests::callgrind::toggle_collect();
+    black_box(benchmark_tests::fibonacci(10))
+}
+
+#[library_benchmark(
+    config = LibraryBenchmarkConfig::default()
+        .output_format(OutputFormat::default()
+            .show_intermediate(true)
+        )
+)]
+#[bench::separate_threads_yes(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "separate-threads=yes",
+        ])
+)]
+#[bench::separate_threads_no(
+    config = LibraryBenchmarkConfig::default()
+        .callgrind_args([
+            "separate-threads=no",
+        ])
+)]
+fn bench_multi_threads() -> Vec<u64> {
+    black_box(benchmark_tests::find_primes_multi_thread_with_instrumentation(2))
+}
+
+library_benchmark_group!(
+    name = my_group;
+    benchmarks =
+        bench_library,
+        bench_with_client_request,
+        bench_multi_threads
+);
+main!(library_benchmark_groups = my_group);

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -585,6 +585,8 @@ impl BenchmarkOutput {
                     || desc.starts_with("Estimated Cycles")
                     || desc.starts_with("L2 Hits")
                     || desc.starts_with("L1 Hits")
+                    || desc.starts_with("SysTime")
+                    || desc.starts_with("SysCpuTime")
                     || desc.starts_with("Suppressed Errors")
                     || desc.starts_with("Suppressed Contexts")
                     || desc.starts_with("At t-gmax bytes")

--- a/benchmark-tests/src/lib.rs
+++ b/benchmark-tests/src/lib.rs
@@ -55,7 +55,9 @@ pub fn find_primes_multi_thread_with_instrumentation(num_threads: usize) -> Vec<
     for _ in 0..num_threads {
         let handle = std::thread::spawn(move || {
             iai_callgrind::client_requests::callgrind::start_instrumentation();
+            iai_callgrind::client_requests::callgrind::toggle_collect();
             let result = find_primes(low, low + 10000);
+            iai_callgrind::client_requests::callgrind::toggle_collect();
             iai_callgrind::client_requests::callgrind::stop_instrumentation();
             result
         });

--- a/iai-callgrind-runner/src/api.rs
+++ b/iai-callgrind-runner/src/api.rs
@@ -65,7 +65,7 @@ pub struct BinaryBenchmarkGroup {
 }
 
 /// The model for the main! macro
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BinaryBenchmarkGroups {
     pub config: BinaryBenchmarkConfig,
     pub groups: Vec<BinaryBenchmarkGroup>,
@@ -96,12 +96,6 @@ pub enum DelayKind {
     PathExists(PathBuf),
 }
 
-impl Default for DelayKind {
-    fn default() -> Self {
-        Self::DurationElapse(Duration::from_secs(60))
-    }
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Command {
     pub path: PathBuf,
@@ -116,7 +110,7 @@ pub struct Command {
 /// The `Direction` in which the flamegraph should grow.
 ///
 /// The default is `TopToBottom`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Direction {
     /// Grow from top to bottom with the highest event costs at the top
     TopToBottom,
@@ -195,7 +189,6 @@ pub enum ErrorMetricKind {
 /// documentation](https://valgrind.org/docs/manual/cl-manual.html#cl-manual.options) for details.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-
 pub enum EventKind {
     /// The default event. I cache reads (which equals the number of instructions executed)
     Ir,
@@ -283,7 +276,7 @@ pub struct FlamegraphConfig {
 }
 
 /// The kind of `Flamegraph` which is going to be constructed
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlamegraphKind {
     /// The regular flamegraph for the new callgrind run
     Regular,
@@ -297,14 +290,14 @@ pub enum FlamegraphKind {
 }
 
 /// The model for the `#[library_benchmark]` attribute
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct LibraryBenchmark {
     pub config: Option<LibraryBenchmarkConfig>,
     pub benches: Vec<LibraryBenchmarkBench>,
 }
 
 /// The model for the `#[bench]` attribute in a `#[library_benchmark]`
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct LibraryBenchmarkBench {
     pub id: Option<String>,
     pub function_name: String,
@@ -327,7 +320,7 @@ pub struct LibraryBenchmarkConfig {
 }
 
 /// The model for the `library_benchmark_group` macro
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct LibraryBenchmarkGroup {
     pub id: String,
     pub config: Option<LibraryBenchmarkConfig>,
@@ -338,7 +331,7 @@ pub struct LibraryBenchmarkGroup {
 }
 
 /// The model for the `main` macro
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct LibraryBenchmarkGroups {
     pub config: LibraryBenchmarkConfig,
     pub groups: Vec<LibraryBenchmarkGroup>,
@@ -375,7 +368,7 @@ pub struct Sandbox {
 /// Configure the `Stream` which should be used as pipe in [`Stdin::Setup`]
 ///
 /// The default is [`Pipe::Stdout`]
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Pipe {
     /// The `Stdout` default `Stream`
     #[default]
@@ -443,7 +436,7 @@ pub struct Tool {
 pub struct Tools(pub Vec<Tool>);
 
 /// The valgrind tools which can be run in addition to callgrind
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ValgrindTool {
     /// [Memcheck: a memory error detector](https://valgrind.org/docs/manual/mc-manual.html)
     Memcheck,
@@ -511,6 +504,12 @@ impl BinaryBenchmarkConfig {
             .iter()
             .filter_map(|(key, option)| option.as_ref().map(|value| (key.clone(), value.clone())))
             .collect()
+    }
+}
+
+impl Default for DelayKind {
+    fn default() -> Self {
+        Self::DurationElapse(Duration::from_secs(60))
     }
 }
 

--- a/iai-callgrind-runner/src/runner/bin_bench.rs
+++ b/iai-callgrind-runner/src/runner/bin_bench.rs
@@ -384,7 +384,7 @@ impl BinBench {
                     (group_index, bench_index),
                     stdin.as_ref().and_then(|s| {
                         if let Stdin::Setup(p) = s {
-                            Some(p.clone())
+                            Some(*p)
                         } else {
                             None
                         }

--- a/iai-callgrind/src/lib_bench.rs
+++ b/iai-callgrind/src/lib_bench.rs
@@ -25,7 +25,7 @@ use crate::{internal, EntryPoint};
 /// );
 /// # }
 /// ```
-#[derive(Debug, Default, IntoInner, AsRef)]
+#[derive(Debug, Default, IntoInner, AsRef, Clone)]
 pub struct LibraryBenchmarkConfig(internal::InternalLibraryBenchmarkConfig);
 
 impl LibraryBenchmarkConfig {


### PR DESCRIPTION
### Added

* Benchmark test which runs all callgrind command-line arguments to check for errors and correct terminal output

### Fixed

* `iai_callgrind::LibraryBenchmarkConfig` was missing the `Clone` derive impl.