### PR TITLE
Change grouping by part -> thread to thread -> part

### DIFF
--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1a
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1a
@@ -2,7 +2,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   ======= CALLGRIND ====================================================================
 1999000
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/subprocess <__ABS_PATH__>/sort
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -10,7 +10,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/sort
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1b
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1b
@@ -2,7 +2,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   ======= CALLGRIND ====================================================================
 1999000
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/subprocess <__ABS_PATH__>/sort
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -10,7 +10,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/sort
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1a
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1a
@@ -2,7 +2,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   ======= CALLGRIND ====================================================================
 1999000
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/subprocess <__ABS_PATH__>/sort
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -10,7 +10,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/sort
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1b
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1b
@@ -2,7 +2,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   ======= CALLGRIND ====================================================================
 1999000
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/subprocess <__ABS_PATH__>/sort
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -10,7 +10,7 @@ test_bin_bench_tools::bench_group::bench_subprocess trace_children:() -> target/
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/sort
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1a
@@ -144,7 +144,7 @@ test_lib_bench_all_args::my_group::bench_with_client_request data_collection_opt
 test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_yes
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -152,7 +152,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -160,7 +160,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1b
@@ -144,7 +144,7 @@ test_lib_bench_all_args::my_group::bench_with_client_request data_collection_opt
 test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_yes
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -152,7 +152,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -160,7 +160,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.freebsd.1a
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.freebsd.1a
@@ -143,7 +143,7 @@ test_lib_bench_all_args::my_group::bench_with_client_request data_collection_opt
 test_lib_bench_all_args::my_group::bench_multi_threads separate_threads_yes
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -151,7 +151,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -159,7 +159,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1a
@@ -23,7 +23,7 @@ test_lib_bench_output_format::my_group::bench_with_format for_comparison:"Anothe
 Benchmark with formatting options
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-|-## pid: <__PID__> part: 1 thread: 1      |N/A
+|-## pid: <__PID__> thread: 1 part: 1      |N/A
 | Command: <__COMMAND__>
 | Instructions:                            |N/A                  (*********)
 | L1 Hits:                                 |N/A                  (*********)
@@ -31,7 +31,7 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |N/A                  (*********)
 | Total read+write:                        |N/A                  (*********)
 | Estimated Cycles:                        |N/A                  (*********)
-|-## pid: <__PID__> part: 1 thread: 2      |N/A
+|-## pid: <__PID__> thread: 2 part: 1      |N/A
 | Command: <__COMMAND__>
 | Instructions:                            |N/A                  (*********)
 | L1 Hits:                                 |N/A                  (*********)
@@ -39,7 +39,7 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |N/A                  (*********)
 | Total read+write:                        |N/A                  (*********)
 | Estimated Cycles:                        |N/A                  (*********)
-|-## pid: <__PID__> part: 1 thread: 3      |N/A
+|-## pid: <__PID__> thread: 3 part: 1      |N/A
 | Command: <__COMMAND__>
 | Instructions:                            |N/A                  (*********)
 | L1 Hits:                                 |N/A                  (*********)
@@ -47,7 +47,7 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |N/A                  (*********)
 | Total read+write:                        |N/A                  (*********)
 | Estimated Cycles:                        |N/A                  (*********)
-|-## pid: <__PID__> part: 1 thread: 4      |N/A
+|-## pid: <__PID__> thread: 4 part: 1      |N/A
 | Command: <__COMMAND__>
 | Instructions:                            |N/A                  (*********)
 | L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1b
@@ -23,7 +23,7 @@ test_lib_bench_output_format::my_group::bench_with_format for_comparison:"Anothe
 Benchmark with formatting options
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-|-## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+|-## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
 | Command: <__COMMAND__>
 | Instructions:                            |                     (No change)
 | L1 Hits:                                 |                     (         )
@@ -31,7 +31,7 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |                     (         )
 | Total read+write:                        |                     (No change)
 | Estimated Cycles:                        |                     (         )
-|-## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+|-## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
 | Command: <__COMMAND__>
 | Instructions:                            |                     (No change)
 | L1 Hits:                                 |                     (         )
@@ -39,7 +39,7 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |                     (         )
 | Total read+write:                        |                     (No change)
 | Estimated Cycles:                        |                     (         )
-|-## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+|-## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
 | Command: <__COMMAND__>
 | Instructions:                            |                     (No change)
 | L1 Hits:                                 |                     (         )
@@ -47,7 +47,7 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |                     (         )
 | Total read+write:                        |                     (No change)
 | Estimated Cycles:                        |                     (         )
-|-## pid: <__PID__> part: 1 thread: 4      |pid: <__PID__> part: 1 thread: 4
+|-## pid: <__PID__> thread: 4 part: 1      |pid: <__PID__> thread: 4 part: 1
 | Command: <__COMMAND__>
 | Instructions:                            |                     (No change)
 | L1 Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/parts/expected_files.1.67.1.yml
+++ b/benchmark-tests/benches/test_lib_bench/parts/expected_files.1.67.1.yml
@@ -5,8 +5,8 @@ data:
     expected:
       files:
         - callgrind.bench_no_thread.dump_after.log
-        - callgrind.bench_no_thread.dump_after.p1.t1.out
-        - callgrind.bench_no_thread.dump_after.p2.t1.out
+        - callgrind.bench_no_thread.dump_after.t1.p1.out
+        - callgrind.bench_no_thread.dump_after.t1.p2.out
         - summary.json
   - group: my_group
     function: bench_no_thread
@@ -14,8 +14,8 @@ data:
     expected:
       files:
         - callgrind.bench_no_thread.dump_before.log
-        - callgrind.bench_no_thread.dump_before.p1.t1.out
-        - callgrind.bench_no_thread.dump_before.p2.t1.out
+        - callgrind.bench_no_thread.dump_before.t1.p1.out
+        - callgrind.bench_no_thread.dump_before.t1.p2.out
         - summary.json
   - group: my_group
     function: bench_no_thread
@@ -23,11 +23,11 @@ data:
     expected:
       files:
         - callgrind.bench_no_thread.dump_every_bb.log
-        - callgrind.bench_no_thread.dump_every_bb.p1.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p2.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p3.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p4.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p5.t1.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p1.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p2.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p3.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p4.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p5.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads
@@ -35,11 +35,11 @@ data:
     expected:
       files:
         - callgrind.bench_multiple_threads.dump_after.log
-        - callgrind.bench_multiple_threads.dump_after.p1.t2.out
-        - callgrind.bench_multiple_threads.dump_after.p2.t3.out
-        - callgrind.bench_multiple_threads.dump_after.p3.t1.out
-        - callgrind.bench_multiple_threads.dump_after.p3.t2.out
-        - callgrind.bench_multiple_threads.dump_after.p3.t3.out
+        - callgrind.bench_multiple_threads.dump_after.t1.p3.out
+        - callgrind.bench_multiple_threads.dump_after.t2.p1.out
+        - callgrind.bench_multiple_threads.dump_after.t2.p3.out
+        - callgrind.bench_multiple_threads.dump_after.t3.p2.out
+        - callgrind.bench_multiple_threads.dump_after.t3.p3.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads
@@ -47,11 +47,11 @@ data:
     expected:
       files:
         - callgrind.bench_multiple_threads.dump_before.log
-        - callgrind.bench_multiple_threads.dump_before.p1.t2.out
-        - callgrind.bench_multiple_threads.dump_before.p2.t3.out
-        - callgrind.bench_multiple_threads.dump_before.p3.t1.out
-        - callgrind.bench_multiple_threads.dump_before.p3.t2.out
-        - callgrind.bench_multiple_threads.dump_before.p3.t3.out
+        - callgrind.bench_multiple_threads.dump_before.t1.p3.out
+        - callgrind.bench_multiple_threads.dump_before.t2.p1.out
+        - callgrind.bench_multiple_threads.dump_before.t2.p3.out
+        - callgrind.bench_multiple_threads.dump_before.t3.p2.out
+        - callgrind.bench_multiple_threads.dump_before.t3.p3.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads
@@ -59,14 +59,14 @@ data:
     expected:
       files:
         - callgrind.bench_multiple_threads.dump_every_bb.log
-        - callgrind.bench_multiple_threads.dump_every_bb.p1.t1.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p1.t2.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p2.t1.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p2.t2.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p2.t3.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p3.t1.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p3.t2.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p3.t3.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t1.p1.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t1.p2.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t1.p3.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t2.p1.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t2.p2.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t2.p3.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t3.p2.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t3.p3.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads_in_subprocess
@@ -77,13 +77,13 @@ data:
           count: 2
         - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.out
           count: 5
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p1.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t1.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p2.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t2.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p2.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p2.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t3.p2.out
           count: 1
       files:
         - summary.json
@@ -96,13 +96,13 @@ data:
           count: 2
         - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.out
           count: 5
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p1.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t1.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p2.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t2.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p2.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p2.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t3.p2.out
           count: 1
       files:
         - summary.json
@@ -115,17 +115,17 @@ data:
           count: 2
         - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.out
           count: 7
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p1.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p1.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t1.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p1.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p2.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t2.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p2.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p2.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t3.p2.out
           count: 1
       files:
         - summary.json

--- a/benchmark-tests/benches/test_lib_bench/parts/expected_files.yml
+++ b/benchmark-tests/benches/test_lib_bench/parts/expected_files.yml
@@ -5,8 +5,8 @@ data:
     expected:
       files:
         - callgrind.bench_no_thread.dump_after.log
-        - callgrind.bench_no_thread.dump_after.p1.t1.out
-        - callgrind.bench_no_thread.dump_after.p2.t1.out
+        - callgrind.bench_no_thread.dump_after.t1.p1.out
+        - callgrind.bench_no_thread.dump_after.t1.p2.out
         - summary.json
   - group: my_group
     function: bench_no_thread
@@ -14,8 +14,8 @@ data:
     expected:
       files:
         - callgrind.bench_no_thread.dump_before.log
-        - callgrind.bench_no_thread.dump_before.p1.t1.out
-        - callgrind.bench_no_thread.dump_before.p2.t1.out
+        - callgrind.bench_no_thread.dump_before.t1.p1.out
+        - callgrind.bench_no_thread.dump_before.t1.p2.out
         - summary.json
   - group: my_group
     function: bench_no_thread
@@ -23,11 +23,11 @@ data:
     expected:
       files:
         - callgrind.bench_no_thread.dump_every_bb.log
-        - callgrind.bench_no_thread.dump_every_bb.p1.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p2.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p3.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p4.t1.out
-        - callgrind.bench_no_thread.dump_every_bb.p5.t1.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p1.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p2.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p3.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p4.out
+        - callgrind.bench_no_thread.dump_every_bb.t1.p5.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads
@@ -35,11 +35,11 @@ data:
     expected:
       files:
         - callgrind.bench_multiple_threads.dump_after.log
-        - callgrind.bench_multiple_threads.dump_after.p1.t2.out
-        - callgrind.bench_multiple_threads.dump_after.p2.t3.out
-        - callgrind.bench_multiple_threads.dump_after.p3.t1.out
-        - callgrind.bench_multiple_threads.dump_after.p3.t2.out
-        - callgrind.bench_multiple_threads.dump_after.p3.t3.out
+        - callgrind.bench_multiple_threads.dump_after.t1.p3.out
+        - callgrind.bench_multiple_threads.dump_after.t2.p1.out
+        - callgrind.bench_multiple_threads.dump_after.t2.p3.out
+        - callgrind.bench_multiple_threads.dump_after.t3.p2.out
+        - callgrind.bench_multiple_threads.dump_after.t3.p3.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads
@@ -47,11 +47,11 @@ data:
     expected:
       files:
         - callgrind.bench_multiple_threads.dump_before.log
-        - callgrind.bench_multiple_threads.dump_before.p1.t2.out
-        - callgrind.bench_multiple_threads.dump_before.p2.t3.out
-        - callgrind.bench_multiple_threads.dump_before.p3.t1.out
-        - callgrind.bench_multiple_threads.dump_before.p3.t2.out
-        - callgrind.bench_multiple_threads.dump_before.p3.t3.out
+        - callgrind.bench_multiple_threads.dump_before.t1.p3.out
+        - callgrind.bench_multiple_threads.dump_before.t2.p1.out
+        - callgrind.bench_multiple_threads.dump_before.t2.p3.out
+        - callgrind.bench_multiple_threads.dump_before.t3.p2.out
+        - callgrind.bench_multiple_threads.dump_before.t3.p3.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads
@@ -59,17 +59,17 @@ data:
     expected:
       files:
         - callgrind.bench_multiple_threads.dump_every_bb.log
-        - callgrind.bench_multiple_threads.dump_every_bb.p1.t1.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p1.t2.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p2.t1.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p2.t2.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p2.t3.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p3.t1.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p3.t2.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p3.t3.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p4.t1.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p4.t2.out
-        - callgrind.bench_multiple_threads.dump_every_bb.p4.t3.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t1.p1.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t1.p2.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t1.p3.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t1.p4.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t2.p1.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t2.p2.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t2.p3.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t2.p4.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t3.p2.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t3.p3.out
+        - callgrind.bench_multiple_threads.dump_every_bb.t3.p4.out
         - summary.json
   - group: my_group
     function: bench_multiple_threads_in_subprocess
@@ -80,13 +80,13 @@ data:
           count: 2
         - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.out
           count: 5
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p1.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t1.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p2.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t2.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p2.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.p2.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_after.*.t3.p2.out
           count: 1
       files:
         - summary.json
@@ -99,13 +99,13 @@ data:
           count: 2
         - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.out
           count: 5
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p1.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t1.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p2.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t2.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p2.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.p2.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_before.*.t3.p2.out
           count: 1
       files:
         - summary.json
@@ -118,23 +118,23 @@ data:
           count: 2
         - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.out
           count: 10
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p1.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p1.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t1.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p1.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t1.p3.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p2.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p2.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t2.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p2.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t2.p3.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p3.t1.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p3.t2.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t3.p2.out
           count: 1
-        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.p3.t3.out
+        - pattern: callgrind.bench_multiple_threads_in_subprocess.dump_every_bb.*.t3.p3.out
           count: 1
       files:
         - summary.json

--- a/benchmark-tests/benches/test_lib_bench/parts/expected_stdout
+++ b/benchmark-tests/benches/test_lib_bench/parts/expected_stdout
@@ -1,6 +1,6 @@
 test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -8,7 +8,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -16,7 +16,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -24,7 +24,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 4 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 4      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -32,7 +32,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 5 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 5      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -49,7 +49,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   Estimated Cycles:                        |N/A                  (*********)
 test_lib_bench_parts::my_group::bench_no_thread dump_before
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -57,7 +57,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_before
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -74,7 +74,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_before
   Estimated Cycles:                        |N/A                  (*********)
 test_lib_bench_parts::my_group::bench_no_thread dump_after
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -82,7 +82,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_after
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -100,7 +100,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_after
 test_lib_bench_parts::my_group::bench_multiple_threads dump_every_bb
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -108,7 +108,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -116,7 +116,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -124,7 +124,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 4      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -132,7 +132,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -140,7 +140,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -148,7 +148,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -156,7 +156,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 4      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -164,7 +164,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 4 thread: 1      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -172,7 +172,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 4 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -180,7 +180,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 4 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 4      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -198,7 +198,7 @@ Number of primes found in the range 0 to 20000: 2262
 test_lib_bench_parts::my_group::bench_multiple_threads dump_before
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -206,7 +206,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -214,7 +214,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -222,7 +222,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -230,7 +230,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -248,7 +248,7 @@ Number of primes found in the range 0 to 20000: 2262
 test_lib_bench_parts::my_group::bench_multiple_threads dump_after
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -256,7 +256,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -264,7 +264,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -272,7 +272,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -280,7 +280,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -298,7 +298,7 @@ Number of primes found in the range 0 to 20000: 2262
 test_lib_bench_parts::my_group::bench_multiple_threads_in_subprocess dump_every_bb
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -306,7 +306,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -314,7 +314,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -322,7 +322,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -330,7 +330,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -338,7 +338,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -346,7 +346,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 3      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -354,7 +354,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -362,7 +362,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -370,7 +370,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 3      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -388,7 +388,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 test_lib_bench_parts::my_group::bench_multiple_threads_in_subprocess dump_before
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -396,7 +396,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -404,7 +404,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -412,7 +412,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -420,7 +420,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -438,7 +438,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 test_lib_bench_parts::my_group::bench_multiple_threads_in_subprocess dump_after
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -446,7 +446,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -454,7 +454,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -462,7 +462,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -470,7 +470,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/parts/expected_stdout.1.67.1
+++ b/benchmark-tests/benches/test_lib_bench/parts/expected_stdout.1.67.1
@@ -1,6 +1,6 @@
 test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -8,7 +8,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -16,7 +16,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -24,7 +24,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 4 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 4      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -32,7 +32,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 5 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 5      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -49,7 +49,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_every_bb
   Estimated Cycles:                        |N/A                  (*********)
 test_lib_bench_parts::my_group::bench_no_thread dump_before
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -57,7 +57,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_before
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -74,7 +74,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_before
   Estimated Cycles:                        |N/A                  (*********)
 test_lib_bench_parts::my_group::bench_no_thread dump_after
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -82,7 +82,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_after
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -100,7 +100,7 @@ test_lib_bench_parts::my_group::bench_no_thread dump_after
 test_lib_bench_parts::my_group::bench_multiple_threads dump_every_bb
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -108,7 +108,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -116,7 +116,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -124,7 +124,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -132,7 +132,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -140,7 +140,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -148,7 +148,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -156,7 +156,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -174,7 +174,7 @@ Number of primes found in the range 0 to 20000: 2262
 test_lib_bench_parts::my_group::bench_multiple_threads dump_before
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -182,7 +182,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -190,7 +190,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -198,7 +198,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -206,7 +206,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -224,7 +224,7 @@ Number of primes found in the range 0 to 20000: 2262
 test_lib_bench_parts::my_group::bench_multiple_threads dump_after
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -232,7 +232,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -240,7 +240,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -248,7 +248,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -256,7 +256,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 3 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 3      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -274,7 +274,7 @@ Number of primes found in the range 0 to 20000: 2262
 test_lib_bench_parts::my_group::bench_multiple_threads_in_subprocess dump_every_bb
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -282,7 +282,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -290,7 +290,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -298,7 +298,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -306,7 +306,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -314,7 +314,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -322,7 +322,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -340,7 +340,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 test_lib_bench_parts::my_group::bench_multiple_threads_in_subprocess dump_before
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -348,7 +348,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -356,7 +356,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -364,7 +364,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -372,7 +372,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -390,7 +390,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 test_lib_bench_parts::my_group::bench_multiple_threads_in_subprocess dump_after
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -398,7 +398,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 1 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -406,7 +406,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 1      |N/A
+  ## pid: <__PID__> thread: 2 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -414,7 +414,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 2      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -422,7 +422,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 2 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 2      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_files.1a.yml
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_files.1a.yml
@@ -5,9 +5,9 @@ data:
     expected:
       files:
         - callgrind.bench_find_primes_multi_thread.two.log
-        - callgrind.bench_find_primes_multi_thread.two.t1.out
-        - callgrind.bench_find_primes_multi_thread.two.t2.out
-        - callgrind.bench_find_primes_multi_thread.two.t3.out
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out
         - dhat.bench_find_primes_multi_thread.two.log
         - dhat.bench_find_primes_multi_thread.two.out
         - drd.bench_find_primes_multi_thread.two.log
@@ -26,10 +26,10 @@ data:
     expected:
       files:
         - callgrind.bench_find_primes_multi_thread.three.log
-        - callgrind.bench_find_primes_multi_thread.three.t1.out
-        - callgrind.bench_find_primes_multi_thread.three.t2.out
-        - callgrind.bench_find_primes_multi_thread.three.t3.out
-        - callgrind.bench_find_primes_multi_thread.three.t4.out
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out
         - dhat.bench_find_primes_multi_thread.three.log
         - dhat.bench_find_primes_multi_thread.three.out
         - drd.bench_find_primes_multi_thread.three.log
@@ -52,11 +52,11 @@ data:
           count: 2
         - pattern: callgrind.bench_thread_in_subprocess.two.*.out
           count: 4
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.two.*.log
           count: 2
@@ -93,13 +93,13 @@ data:
           count: 2
         - pattern: callgrind.bench_thread_in_subprocess.three.*.out
           count: 5
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.three.*.log
           count: 2
@@ -134,9 +134,9 @@ data:
     expected:
       files:
         - callgrind.bench_thread_in_thread.log
-        - callgrind.bench_thread_in_thread.t1.out
-        - callgrind.bench_thread_in_thread.t2.out
-        - callgrind.bench_thread_in_thread.t3.out
+        - callgrind.bench_thread_in_thread.t1.p1.out
+        - callgrind.bench_thread_in_thread.t2.p1.out
+        - callgrind.bench_thread_in_thread.t3.p1.out
         - dhat.bench_thread_in_thread.log
         - dhat.bench_thread_in_thread.out
         - drd.bench_thread_in_thread.log
@@ -157,11 +157,11 @@ data:
           count: 2
         - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.out
           count: 4
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out
           count: 1
         - pattern: dhat.bench_thread_in_thread_in_subprocess.*.log
           count: 2

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_files.1b.yml
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_files.1b.yml
@@ -6,12 +6,12 @@ data:
       files:
         - callgrind.bench_find_primes_multi_thread.two.log
         - callgrind.bench_find_primes_multi_thread.two.log.old
-        - callgrind.bench_find_primes_multi_thread.two.t1.out
-        - callgrind.bench_find_primes_multi_thread.two.t1.out.old
-        - callgrind.bench_find_primes_multi_thread.two.t2.out
-        - callgrind.bench_find_primes_multi_thread.two.t2.out.old
-        - callgrind.bench_find_primes_multi_thread.two.t3.out
-        - callgrind.bench_find_primes_multi_thread.two.t3.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out.old
         - dhat.bench_find_primes_multi_thread.two.log
         - dhat.bench_find_primes_multi_thread.two.log.old
         - dhat.bench_find_primes_multi_thread.two.out
@@ -42,14 +42,14 @@ data:
       files:
         - callgrind.bench_find_primes_multi_thread.three.log
         - callgrind.bench_find_primes_multi_thread.three.log.old
-        - callgrind.bench_find_primes_multi_thread.three.t1.out
-        - callgrind.bench_find_primes_multi_thread.three.t1.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t2.out
-        - callgrind.bench_find_primes_multi_thread.three.t2.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t3.out
-        - callgrind.bench_find_primes_multi_thread.three.t3.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t4.out
-        - callgrind.bench_find_primes_multi_thread.three.t4.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out.old
         - dhat.bench_find_primes_multi_thread.three.log
         - dhat.bench_find_primes_multi_thread.three.log.old
         - dhat.bench_find_primes_multi_thread.three.out
@@ -88,17 +88,17 @@ data:
           count: 4
         - pattern: callgrind.bench_thread_in_subprocess.two.*.out.old
           count: 4
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.two.*.log
           count: 2
@@ -163,21 +163,21 @@ data:
           count: 5
         - pattern: callgrind.bench_thread_in_subprocess.three.*.out.old
           count: 5
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.three.*.log
           count: 2
@@ -239,12 +239,12 @@ data:
       files:
         - callgrind.bench_thread_in_thread.log
         - callgrind.bench_thread_in_thread.log.old
-        - callgrind.bench_thread_in_thread.t1.out
-        - callgrind.bench_thread_in_thread.t1.out.old
-        - callgrind.bench_thread_in_thread.t2.out
-        - callgrind.bench_thread_in_thread.t2.out.old
-        - callgrind.bench_thread_in_thread.t3.out
-        - callgrind.bench_thread_in_thread.t3.out.old
+        - callgrind.bench_thread_in_thread.t1.p1.out
+        - callgrind.bench_thread_in_thread.t1.p1.out.old
+        - callgrind.bench_thread_in_thread.t2.p1.out
+        - callgrind.bench_thread_in_thread.t2.p1.out.old
+        - callgrind.bench_thread_in_thread.t3.p1.out
+        - callgrind.bench_thread_in_thread.t3.p1.out.old
         - dhat.bench_thread_in_thread.log
         - dhat.bench_thread_in_thread.log.old
         - dhat.bench_thread_in_thread.out
@@ -280,17 +280,17 @@ data:
           count: 4
         - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.out.old
           count: 4
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_thread_in_subprocess.*.log
           count: 2

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_files.1d.yml
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_files.1d.yml
@@ -7,15 +7,15 @@ data:
         - callgrind.bench_find_primes_multi_thread.two.log
         - callgrind.bench_find_primes_multi_thread.two.log.base@default
         - callgrind.bench_find_primes_multi_thread.two.log.old
-        - callgrind.bench_find_primes_multi_thread.two.t1.out
-        - callgrind.bench_find_primes_multi_thread.two.t1.out.base@default
-        - callgrind.bench_find_primes_multi_thread.two.t1.out.old
-        - callgrind.bench_find_primes_multi_thread.two.t2.out
-        - callgrind.bench_find_primes_multi_thread.two.t2.out.base@default
-        - callgrind.bench_find_primes_multi_thread.two.t2.out.old
-        - callgrind.bench_find_primes_multi_thread.two.t3.out
-        - callgrind.bench_find_primes_multi_thread.two.t3.out.base@default
-        - callgrind.bench_find_primes_multi_thread.two.t3.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out.old
         - dhat.bench_find_primes_multi_thread.two.log
         - dhat.bench_find_primes_multi_thread.two.log.base@default
         - dhat.bench_find_primes_multi_thread.two.log.old
@@ -58,18 +58,18 @@ data:
         - callgrind.bench_find_primes_multi_thread.three.log
         - callgrind.bench_find_primes_multi_thread.three.log.base@default
         - callgrind.bench_find_primes_multi_thread.three.log.old
-        - callgrind.bench_find_primes_multi_thread.three.t1.out
-        - callgrind.bench_find_primes_multi_thread.three.t1.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t1.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t2.out
-        - callgrind.bench_find_primes_multi_thread.three.t2.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t2.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t3.out
-        - callgrind.bench_find_primes_multi_thread.three.t3.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t3.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t4.out
-        - callgrind.bench_find_primes_multi_thread.three.t4.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t4.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out.old
         - dhat.bench_find_primes_multi_thread.three.log
         - dhat.bench_find_primes_multi_thread.three.log.base@default
         - dhat.bench_find_primes_multi_thread.three.log.old
@@ -124,23 +124,23 @@ data:
           count: 4
         - pattern: callgrind.bench_thread_in_subprocess.two.*.out.old
           count: 4
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.two.*.log
           count: 2
@@ -233,29 +233,29 @@ data:
           count: 5
         - pattern: callgrind.bench_thread_in_subprocess.three.*.out.old
           count: 5
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.three.*.log
           count: 2
@@ -344,15 +344,15 @@ data:
         - callgrind.bench_thread_in_thread.log
         - callgrind.bench_thread_in_thread.log.base@default
         - callgrind.bench_thread_in_thread.log.old
-        - callgrind.bench_thread_in_thread.t1.out
-        - callgrind.bench_thread_in_thread.t1.out.base@default
-        - callgrind.bench_thread_in_thread.t1.out.old
-        - callgrind.bench_thread_in_thread.t2.out
-        - callgrind.bench_thread_in_thread.t2.out.base@default
-        - callgrind.bench_thread_in_thread.t2.out.old
-        - callgrind.bench_thread_in_thread.t3.out
-        - callgrind.bench_thread_in_thread.t3.out.base@default
-        - callgrind.bench_thread_in_thread.t3.out.old
+        - callgrind.bench_thread_in_thread.t1.p1.out
+        - callgrind.bench_thread_in_thread.t1.p1.out.base@default
+        - callgrind.bench_thread_in_thread.t1.p1.out.old
+        - callgrind.bench_thread_in_thread.t2.p1.out
+        - callgrind.bench_thread_in_thread.t2.p1.out.base@default
+        - callgrind.bench_thread_in_thread.t2.p1.out.old
+        - callgrind.bench_thread_in_thread.t3.p1.out
+        - callgrind.bench_thread_in_thread.t3.p1.out.base@default
+        - callgrind.bench_thread_in_thread.t3.p1.out.old
         - dhat.bench_thread_in_thread.log
         - dhat.bench_thread_in_thread.log.base@default
         - dhat.bench_thread_in_thread.log.old
@@ -403,23 +403,23 @@ data:
           count: 4
         - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.out.old
           count: 4
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out.base@default
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out.base@default
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out.base@default
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_thread_in_subprocess.*.log
           count: 2

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_files.1e.yml
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_files.1e.yml
@@ -8,18 +8,18 @@ data:
         - callgrind.bench_find_primes_multi_thread.two.log.base@default
         - callgrind.bench_find_primes_multi_thread.two.log.base@foo
         - callgrind.bench_find_primes_multi_thread.two.log.old
-        - callgrind.bench_find_primes_multi_thread.two.t1.out
-        - callgrind.bench_find_primes_multi_thread.two.t1.out.base@default
-        - callgrind.bench_find_primes_multi_thread.two.t1.out.base@foo
-        - callgrind.bench_find_primes_multi_thread.two.t1.out.old
-        - callgrind.bench_find_primes_multi_thread.two.t2.out
-        - callgrind.bench_find_primes_multi_thread.two.t2.out.base@default
-        - callgrind.bench_find_primes_multi_thread.two.t2.out.base@foo
-        - callgrind.bench_find_primes_multi_thread.two.t2.out.old
-        - callgrind.bench_find_primes_multi_thread.two.t3.out
-        - callgrind.bench_find_primes_multi_thread.two.t3.out.base@default
-        - callgrind.bench_find_primes_multi_thread.two.t3.out.base@foo
-        - callgrind.bench_find_primes_multi_thread.two.t3.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out.base@foo
+        - callgrind.bench_find_primes_multi_thread.two.t1.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out.base@foo
+        - callgrind.bench_find_primes_multi_thread.two.t2.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out.base@foo
+        - callgrind.bench_find_primes_multi_thread.two.t3.p1.out.old
         - dhat.bench_find_primes_multi_thread.two.log
         - dhat.bench_find_primes_multi_thread.two.log.base@default
         - dhat.bench_find_primes_multi_thread.two.log.base@foo
@@ -74,22 +74,22 @@ data:
         - callgrind.bench_find_primes_multi_thread.three.log.base@default
         - callgrind.bench_find_primes_multi_thread.three.log.base@foo
         - callgrind.bench_find_primes_multi_thread.three.log.old
-        - callgrind.bench_find_primes_multi_thread.three.t1.out
-        - callgrind.bench_find_primes_multi_thread.three.t1.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t1.out.base@foo
-        - callgrind.bench_find_primes_multi_thread.three.t1.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t2.out
-        - callgrind.bench_find_primes_multi_thread.three.t2.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t2.out.base@foo
-        - callgrind.bench_find_primes_multi_thread.three.t2.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t3.out
-        - callgrind.bench_find_primes_multi_thread.three.t3.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t3.out.base@foo
-        - callgrind.bench_find_primes_multi_thread.three.t3.out.old
-        - callgrind.bench_find_primes_multi_thread.three.t4.out
-        - callgrind.bench_find_primes_multi_thread.three.t4.out.base@default
-        - callgrind.bench_find_primes_multi_thread.three.t4.out.base@foo
-        - callgrind.bench_find_primes_multi_thread.three.t4.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out.base@foo
+        - callgrind.bench_find_primes_multi_thread.three.t1.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out.base@foo
+        - callgrind.bench_find_primes_multi_thread.three.t2.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out.base@foo
+        - callgrind.bench_find_primes_multi_thread.three.t3.p1.out.old
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out.base@default
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out.base@foo
+        - callgrind.bench_find_primes_multi_thread.three.t4.p1.out.old
         - dhat.bench_find_primes_multi_thread.three.log
         - dhat.bench_find_primes_multi_thread.three.log.base@default
         - dhat.bench_find_primes_multi_thread.three.log.base@foo
@@ -160,29 +160,29 @@ data:
           count: 4
         - pattern: callgrind.bench_thread_in_subprocess.two.*.out.old
           count: 4
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out.base@foo
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out.base@foo
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out.base@foo
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.two.*.t3.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.two.*.log
           count: 2
@@ -303,37 +303,37 @@ data:
           count: 5
         - pattern: callgrind.bench_thread_in_subprocess.three.*.out.old
           count: 5
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out.base@foo
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out.base@foo
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out.base@foo
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t3.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out.base@default
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out.base@foo
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.out.old
+        - pattern: callgrind.bench_thread_in_subprocess.three.*.t4.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_subprocess.three.*.log
           count: 2
@@ -449,18 +449,18 @@ data:
         - callgrind.bench_thread_in_thread.log.base@default
         - callgrind.bench_thread_in_thread.log.base@foo
         - callgrind.bench_thread_in_thread.log.old
-        - callgrind.bench_thread_in_thread.t1.out
-        - callgrind.bench_thread_in_thread.t1.out.base@default
-        - callgrind.bench_thread_in_thread.t1.out.base@foo
-        - callgrind.bench_thread_in_thread.t1.out.old
-        - callgrind.bench_thread_in_thread.t2.out
-        - callgrind.bench_thread_in_thread.t2.out.base@default
-        - callgrind.bench_thread_in_thread.t2.out.base@foo
-        - callgrind.bench_thread_in_thread.t2.out.old
-        - callgrind.bench_thread_in_thread.t3.out
-        - callgrind.bench_thread_in_thread.t3.out.base@default
-        - callgrind.bench_thread_in_thread.t3.out.base@foo
-        - callgrind.bench_thread_in_thread.t3.out.old
+        - callgrind.bench_thread_in_thread.t1.p1.out
+        - callgrind.bench_thread_in_thread.t1.p1.out.base@default
+        - callgrind.bench_thread_in_thread.t1.p1.out.base@foo
+        - callgrind.bench_thread_in_thread.t1.p1.out.old
+        - callgrind.bench_thread_in_thread.t2.p1.out
+        - callgrind.bench_thread_in_thread.t2.p1.out.base@default
+        - callgrind.bench_thread_in_thread.t2.p1.out.base@foo
+        - callgrind.bench_thread_in_thread.t2.p1.out.old
+        - callgrind.bench_thread_in_thread.t3.p1.out
+        - callgrind.bench_thread_in_thread.t3.p1.out.base@default
+        - callgrind.bench_thread_in_thread.t3.p1.out.base@foo
+        - callgrind.bench_thread_in_thread.t3.p1.out.old
         - dhat.bench_thread_in_thread.log
         - dhat.bench_thread_in_thread.log.base@default
         - dhat.bench_thread_in_thread.log.base@foo
@@ -526,29 +526,29 @@ data:
           count: 4
         - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.out.old
           count: 4
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out.base@default
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out.base@foo
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t1.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out.base@default
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out.base@foo
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t2.p1.out.old
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out.base@default
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out.base@default
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out.base@foo
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out.base@foo
           count: 1
-        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.out.old
+        - pattern: callgrind.bench_thread_in_thread_in_subprocess.*.t3.p1.out.old
           count: 1
         - pattern: dhat.bench_thread_in_thread_in_subprocess.*.log
           count: 2

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1a
@@ -2,7 +2,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -10,7 +10,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -18,7 +18,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -61,7 +61,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -69,7 +69,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -77,7 +77,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -85,7 +85,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -128,7 +128,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -136,7 +136,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -144,7 +144,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -152,7 +152,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -256,7 +256,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -264,7 +264,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -272,7 +272,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -280,7 +280,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -288,7 +288,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -392,7 +392,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -400,7 +400,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -408,7 +408,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -451,7 +451,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -459,7 +459,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -467,7 +467,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -475,7 +475,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1b
@@ -2,7 +2,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -10,7 +10,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -18,7 +18,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -61,7 +61,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -69,7 +69,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -77,7 +77,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -85,7 +85,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 4      |pid: <__PID__> part: 1 thread: 4
+  ## pid: <__PID__> thread: 4 part: 1      |pid: <__PID__> thread: 4 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -128,7 +128,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -136,7 +136,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -144,7 +144,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -152,7 +152,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -256,7 +256,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -264,7 +264,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -272,7 +272,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -280,7 +280,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -288,7 +288,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 4      |pid: <__PID__> part: 1 thread: 4
+  ## pid: <__PID__> thread: 4 part: 1      |pid: <__PID__> thread: 4 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -392,7 +392,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -400,7 +400,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -408,7 +408,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -451,7 +451,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -459,7 +459,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -467,7 +467,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -475,7 +475,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1d
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1d
@@ -2,7 +2,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                        default|default
   Instructions:                            |N/A                  (*********)
@@ -11,7 +11,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -19,7 +19,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -62,7 +62,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                        default|default
   Instructions:                            |N/A                  (*********)
@@ -71,7 +71,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -79,7 +79,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -87,7 +87,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -130,7 +130,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                        default|default
   Instructions:                            |N/A                  (*********)
@@ -139,7 +139,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -147,7 +147,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -155,7 +155,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -259,7 +259,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                        default|default
   Instructions:                            |N/A                  (*********)
@@ -268,7 +268,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -276,7 +276,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -284,7 +284,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -292,7 +292,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -396,7 +396,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                        default|default
   Instructions:                            |N/A                  (*********)
@@ -405,7 +405,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -413,7 +413,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -456,7 +456,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                        default|default
   Instructions:                            |N/A                  (*********)
@@ -465,7 +465,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -473,7 +473,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -481,7 +481,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1e
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1e
@@ -2,7 +2,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |N/A                  (*********)
@@ -11,7 +11,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -19,7 +19,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -62,7 +62,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |N/A                  (*********)
@@ -71,7 +71,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -79,7 +79,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -87,7 +87,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -130,7 +130,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |N/A                  (*********)
@@ -139,7 +139,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -147,7 +147,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -155,7 +155,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -259,7 +259,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |N/A                  (*********)
@@ -268,7 +268,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -276,7 +276,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -284,7 +284,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -292,7 +292,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -396,7 +396,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |N/A                  (*********)
@@ -405,7 +405,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -413,7 +413,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -456,7 +456,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |N/A                  (*********)
@@ -465,7 +465,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -473,7 +473,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -481,7 +481,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1f
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1f
@@ -1,6 +1,6 @@
 test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   ======= CALLGRIND ====================================================================
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|default
   Instructions:                            |                     (No change)
@@ -9,7 +9,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -17,7 +17,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -58,7 +58,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   Details: <__DETAILS__>
 test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   ======= CALLGRIND ====================================================================
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|default
   Instructions:                            |                     (No change)
@@ -67,7 +67,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -75,7 +75,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -83,7 +83,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 4      |pid: <__PID__> part: 1 thread: 4
+  ## pid: <__PID__> thread: 4 part: 1      |pid: <__PID__> thread: 4 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -124,7 +124,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   Details: <__DETAILS__>
 test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   ======= CALLGRIND ====================================================================
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|default
   Instructions:                            |                     (No change)
@@ -133,7 +133,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -141,7 +141,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -149,7 +149,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -251,7 +251,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   Estimated Cycles:                        |                     (         )
 test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   ======= CALLGRIND ====================================================================
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|default
   Instructions:                            |                     (No change)
@@ -260,7 +260,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -268,7 +268,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -276,7 +276,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -284,7 +284,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 4      |pid: <__PID__> part: 1 thread: 4
+  ## pid: <__PID__> thread: 4 part: 1      |pid: <__PID__> thread: 4 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -386,7 +386,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   Estimated Cycles:                        |                     (         )
 test_lib_bench_threads::bench_group::bench_thread_in_thread
   ======= CALLGRIND ====================================================================
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|default
   Instructions:                            |                     (No change)
@@ -395,7 +395,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -403,7 +403,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -444,7 +444,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   Details: <__DETAILS__>
 test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ======= CALLGRIND ====================================================================
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|default
   Instructions:                            |                     (No change)
@@ -453,7 +453,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -461,7 +461,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -469,7 +469,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1g
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1g
@@ -2,7 +2,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |                     (No change)
@@ -11,7 +11,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -19,7 +19,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -62,7 +62,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |                     (No change)
@@ -71,7 +71,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -79,7 +79,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -87,7 +87,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 4      |pid: <__PID__> part: 1 thread: 4
+  ## pid: <__PID__> thread: 4 part: 1      |pid: <__PID__> thread: 4 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -130,7 +130,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |                     (No change)
@@ -139,7 +139,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -147,7 +147,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -155,7 +155,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread 2
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -259,7 +259,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |                     (No change)
@@ -268,7 +268,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -276,7 +276,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -284,7 +284,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -292,7 +292,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 4      |pid: <__PID__> part: 1 thread: 4
+  ## pid: <__PID__> thread: 4 part: 1      |pid: <__PID__> thread: 4 part: 1
   Command:             target/release/thread 3
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -396,7 +396,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |                     (No change)
@@ -405,7 +405,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -413,7 +413,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -456,7 +456,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Baselines:                            foo|foo
   Instructions:                            |                     (No change)
@@ -465,7 +465,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -473,7 +473,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 2      |pid: <__PID__> part: 1 thread: 2
+  ## pid: <__PID__> thread: 2 part: 1      |pid: <__PID__> thread: 2 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -481,7 +481,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 3      |pid: <__PID__> part: 1 thread: 3
+  ## pid: <__PID__> thread: 3 part: 1      |pid: <__PID__> thread: 3 part: 1
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.freebsd.1a
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.freebsd.1a
@@ -2,7 +2,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -10,7 +10,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -18,7 +18,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -61,7 +61,7 @@ test_lib_bench_threads::bench_group::bench_find_primes_multi_thread three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -69,7 +69,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -77,7 +77,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -85,7 +85,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -128,7 +128,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess two:2
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -136,7 +136,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -144,7 +144,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -152,7 +152,7 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 2
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -257,7 +257,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_subprocess three:3
   ======= CALLGRIND ====================================================================
 Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -265,7 +265,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -273,7 +273,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -281,7 +281,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -289,7 +289,7 @@ Number of primes found in the range 0 to 30000: 3245
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 4      |N/A
+  ## pid: <__PID__> thread: 4 part: 1      |N/A
   Command:             target/release/thread 3
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -394,7 +394,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -402,7 +402,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -410,7 +410,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -453,7 +453,7 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ======= CALLGRIND ====================================================================
 thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -461,7 +461,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -469,7 +469,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 2      |N/A
+  ## pid: <__PID__> thread: 2 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -477,7 +477,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 3      |N/A
+  ## pid: <__PID__> thread: 3 part: 1      |N/A
   Command:             target/release/thread --thread-in-thread
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1a
@@ -40,7 +40,7 @@ test_lib_bench_tools::bench_group::bench_subprocess trace_children
   ======= CALLGRIND ====================================================================
 Do something before calling subprocess
 - end of stdout/stderr
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
@@ -48,7 +48,7 @@ Do something before calling subprocess
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
-  ## pid: <__PID__> part: 1 thread: 1      |N/A
+  ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command:             target/release/sort
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1b
@@ -37,7 +37,7 @@ test_lib_bench_tools::bench_group::bench_bubble_sort_allocate
   Suppressed Contexts:                     |                     (         )
 test_lib_bench_tools::bench_group::bench_subprocess trace_children
   ======= CALLGRIND ====================================================================
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
@@ -45,7 +45,7 @@ test_lib_bench_tools::bench_group::bench_subprocess trace_children
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
-  ## pid: <__PID__> part: 1 thread: 1      |pid: <__PID__> part: 1 thread: 1
+  ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command:             target/release/sort
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )

--- a/iai-callgrind-runner/src/runner/callgrind/parser.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/parser.rs
@@ -82,9 +82,9 @@ impl CallgrindProperties {
     /// See also [Callgrind Format](https://valgrind.org/docs/manual/cl-format.html#cl-format.reference.grammar)
     pub fn compare_target_ids(&self, other: &Self) -> Ordering {
         self.pid.cmp(&other.pid).then_with(|| {
-            self.part
-                .cmp(&other.part)
-                .then_with(|| self.thread.cmp(&other.thread))
+            self.thread
+                .cmp(&other.thread)
+                .then_with(|| self.part.cmp(&other.part))
         })
     }
 }

--- a/iai-callgrind-runner/src/runner/format.rs
+++ b/iai-callgrind-runner/src/runner/format.rs
@@ -676,11 +676,11 @@ impl VerticalFormatter {
             if let Some(ppid) = detail.parent_pid {
                 write!(result, " ppid: {ppid}").unwrap();
             }
-            if let Some(part) = detail.part {
-                write!(result, " part: {part}").unwrap();
-            }
             if let Some(thread) = detail.thread {
                 write!(result, " thread: {thread}").unwrap();
+            }
+            if let Some(part) = detail.part {
+                write!(result, " part: {part}").unwrap();
             }
 
             result


### PR DESCRIPTION
This change affects the terminal output which changes from

```text
  ...
  ## pid: 1234 part: 1 thread: 1
  ...
```

to

```text
  ...
  ## pid: 1234 thread: 1 part: 1
  ...
```

and the file names which change from `callgrind.some.1234.p1.t1.out` to `callgrind.some.1234.t1.p1.out`