### PR TITLE
feat(summary): Print a summary after a bench run

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -1,4 +1,3 @@
-neovim
 ASLR
 Aparicio
 Assche
@@ -142,10 +141,12 @@ mmap
 msvc
 multibyte
 nanomips
+neovim
 noaccess
 nocapture
 nodemon
 noninteractive
+nosummary
 nsec
 outfile
 outfiles

--- a/benchmark-tests/benches/test_bin_bench/client_requests/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/client_requests/expected_stdout.1
@@ -7,3 +7,5 @@ Hello World.
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/command_delay/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/command_delay/expected_stdout.1
@@ -35,3 +35,5 @@ Stopped server...
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 4 without regressions; 0 regressed; 4 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/compare_by_id/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/compare_by_id/expected_stdout.1
@@ -208,3 +208,5 @@ test_bin_bench_compare_by_id::compare_low_level_multiple::low_level_other bar:()
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (+       %) [+       x]
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 22 without regressions; 0 regressed; 22 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/compare_by_id/expected_stdout.2
+++ b/benchmark-tests/benches/test_bin_bench/compare_by_id/expected_stdout.2
@@ -208,3 +208,5 @@ test_bin_bench_compare_by_id::compare_low_level_multiple::low_level_other bar:()
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (+       %) [+       x]
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 22 without regressions; 0 regressed; 22 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/config/expected_stdout
+++ b/benchmark-tests/benches/test_bin_bench/config/expected_stdout
@@ -60,3 +60,5 @@ Found env: 'COMMAND_ENV' with value '5'
   At t-end blocks:                         |N/A                  (*********)
   Reads bytes:                             |N/A                  (*********)
   Writes bytes:                            |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.1
@@ -5,3 +5,5 @@ test_bench_template::my_group::bench_exit_with exit_with:(ExitWith :: Code(0)) -
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.2
+++ b/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.2
@@ -5,3 +5,5 @@ test_bench_template::my_group::bench_exit_with exit_with:(ExitWith :: Success) -
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.3
+++ b/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.3
@@ -5,3 +5,5 @@ test_bench_template::my_group::bench_exit_with exit_with:(ExitWith :: Code(1)) -
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.4
+++ b/benchmark-tests/benches/test_bin_bench/exit_with/expected_stdout.4
@@ -5,3 +5,5 @@ test_bench_template::my_group::bench_exit_with exit_with:(ExitWith :: Failure) -
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/intro/expected_stdout
+++ b/benchmark-tests/benches/test_bin_bench/intro/expected_stdout
@@ -121,3 +121,5 @@ test_bin_bench_intro::pipe_group::bench_pipe bar:("bar") -> target/release/pipe
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 15 without regressions; 0 regressed; 15 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/low_level/expected_stdout
+++ b/benchmark-tests/benches/test_bin_bench/low_level/expected_stdout
@@ -181,3 +181,5 @@ test_bin_bench_low_level::teardown_override::second_override without_teardown_ov
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 20 without regressions; 0 regressed; 20 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/expected_stdout.1
@@ -26,3 +26,5 @@ test_bin_bench_main_and_group_setup_and_teardown::check_group::check_file_not_ex
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
 MAIN TEARDOWN
+
+Iai-Callgrind result: Ok. 3 without regressions; 0 regressed; 3 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/expected_stdout.2
+++ b/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/expected_stdout.2
@@ -22,3 +22,5 @@ test_bin_bench_main_and_group_setup_and_teardown::check_group::check_file_not_ex
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 3 without regressions; 0 regressed; 3 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/paths/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/paths/expected_stdout.1
@@ -34,3 +34,5 @@ content of file
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 4 without regressions; 0 regressed; 4 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/paths/expected_stdout.2
+++ b/benchmark-tests/benches/test_bin_bench/paths/expected_stdout.2
@@ -34,3 +34,5 @@ content of file
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 4 without regressions; 0 regressed; 4 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/regression/expected_stderr.fail-fast
+++ b/benchmark-tests/benches/test_bin_bench/regression/expected_stderr.fail-fast
@@ -1,5 +1,5 @@
-Performance has regressed: Instructions (<__NUM__> > <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>)
-iai_callgrind_runner: Error: Performance has regressed. Aborting ...
+Performance has regressed: Instructions (<__NUM__> -> <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>%)
+iai_callgrind_runner: Error: Performance has regressed. Fail-fast is set. Aborting ...
 error: bench failed, to rerun pass `-p benchmark-tests --bench test_bench_template`
 
 Caused by:

--- a/benchmark-tests/benches/test_bin_bench/regression/expected_stderr.no-fail-fast
+++ b/benchmark-tests/benches/test_bin_bench/regression/expected_stderr.no-fail-fast
@@ -1,5 +1,4 @@
-Performance has regressed: Instructions (<__NUM__> > <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>)
-iai_callgrind_runner: Error: Performance has regressed.
+Performance has regressed: Instructions (<__NUM__> -> <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>%)
 error: bench failed, to rerun pass `-p benchmark-tests --bench test_bench_template`
 
 Caused by:

--- a/benchmark-tests/benches/test_bin_bench/regression/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/regression/expected_stdout.1
@@ -12,3 +12,5 @@ test_bench_template::bench_group::bench_bubble_sort should_not_run_after_regress
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/regression/expected_stdout.no-fail-fast
+++ b/benchmark-tests/benches/test_bin_bench/regression/expected_stdout.no-fail-fast
@@ -12,3 +12,10 @@ test_bench_template::bench_group::bench_bubble_sort should_not_run_after_regress
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Regressions:
+
+  test_bench_template::bench_group::bench_bubble_sort regress_ir:
+    Instructions (<__NUM__> -> <__NUM__>): +<__PERCENT__>% exceeds limit of +<__PERCENT__>%
+
+Iai-Callgrind result: Regressed. 1 without regressions; 1 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/sandbox/expected_stdout
+++ b/benchmark-tests/benches/test_bin_bench/sandbox/expected_stdout
@@ -38,3 +38,5 @@ Deleted directory 'foo' with file 'bar.txt'
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 4 without regressions; 0 regressed; 4 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/setup_and_teardown/expected_stdout.1
+++ b/benchmark-tests/benches/test_bin_bench/setup_and_teardown/expected_stdout.1
@@ -280,3 +280,5 @@ TEARDOWN: teardown_one_argument function: 4
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 27 without regressions; 0 regressed; 27 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/setup_and_teardown/expected_stdout.2
+++ b/benchmark-tests/benches/test_bin_bench/setup_and_teardown/expected_stdout.2
@@ -214,3 +214,5 @@ test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown ov
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 27 without regressions; 0 regressed; 27 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/setup_child/expected_stdout
+++ b/benchmark-tests/benches/test_bin_bench/setup_child/expected_stdout
@@ -7,3 +7,5 @@ SETUP CHILD PROCESS- end of stdout/stderr
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1a
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1a
@@ -160,3 +160,5 @@ test_bin_bench_tools::bench_group::bench_subprocess no_trace_children:() -> targ
   Contexts:                                |N/A                  (*********)
   Suppressed Errors:                       |N/A                  (*********)
   Suppressed Contexts:                     |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1b
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.1b
@@ -160,3 +160,5 @@ test_bin_bench_tools::bench_group::bench_subprocess no_trace_children:() -> targ
   Contexts:                                |                     (No change)
   Suppressed Errors:                       |                     (         )
   Suppressed Contexts:                     |                     (         )
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1a
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1a
@@ -162,3 +162,5 @@ test_bin_bench_tools::bench_group::bench_subprocess no_trace_children:() -> targ
   Contexts:                                |N/A                  (*********)
   Suppressed Errors:                       |N/A                  (*********)
   Suppressed Contexts:                     |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1b
+++ b/benchmark-tests/benches/test_bin_bench/tools/expected_stdout.freebsd.1b
@@ -162,3 +162,5 @@ test_bin_bench_tools::bench_group::bench_subprocess no_trace_children:() -> targ
   Contexts:                                |                     (No change)
   Suppressed Errors:                       |                     (         )
   Suppressed Contexts:                     |                     (         )
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1a
@@ -184,3 +184,5 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 19 without regressions; 0 regressed; 19 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.1b
@@ -184,3 +184,5 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 19 without regressions; 0 regressed; 19 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.freebsd.1a
+++ b/benchmark-tests/benches/test_lib_bench/all_args/expected_stdout.freebsd.1a
@@ -183,3 +183,5 @@ Number of primes found in the range 0 to 20000: 2262
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 19 without regressions; 0 regressed; 19 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/cache_sim/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/cache_sim/expected_stdout.1
@@ -7,3 +7,5 @@ test_lib_bench_cache_sim::bench_cache_sim::bench_with_cache_sim with_10:setup_wo
   Estimated Cycles:                        |N/A                  (*********)
 test_lib_bench_cache_sim::bench_cache_sim::bench_without_cache_sim with_10:setup_worst_case_array(10)
   Instructions:                            |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/cache_sim/expected_stdout.2
+++ b/benchmark-tests/benches/test_lib_bench/cache_sim/expected_stdout.2
@@ -7,3 +7,5 @@ test_lib_bench_cache_sim::bench_cache_sim::bench_with_cache_sim with_10:setup_wo
   Estimated Cycles:                        |                     (         )
 test_lib_bench_cache_sim::bench_cache_sim::bench_without_cache_sim with_10:setup_worst_case_array(10)
   Instructions:                            |                     (No change)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/cache_sim/test_lib_bench_cache_sim.rs
+++ b/benchmark-tests/benches/test_lib_bench/cache_sim/test_lib_bench_cache_sim.rs
@@ -15,13 +15,13 @@ fn setup_worst_case_array(start: i32) -> Vec<i32> {
 }
 
 #[library_benchmark(config = LibraryBenchmarkConfig::default().callgrind_args(["--cache-sim=yes"]))]
-#[bench::with_10(setup_worst_case_array(10))]
+#[bench::with_10(setup_worst_case_array(20))]
 fn bench_with_cache_sim(value: Vec<i32>) -> Vec<i32> {
     black_box(bubble_sort(value))
 }
 
 #[library_benchmark(config = LibraryBenchmarkConfig::default().callgrind_args(["--cache-sim=no"]))]
-#[bench::with_10(setup_worst_case_array(10))]
+#[bench::with_10(setup_worst_case_array(20))]
 fn bench_without_cache_sim(value: Vec<i32>) -> Vec<i32> {
     black_box(bubble_sort(value))
 }
@@ -33,6 +33,6 @@ library_benchmark_group!(
 
 main!(
     config = LibraryBenchmarkConfig::default()
-        .regression(RegressionConfig::default())
+        .regression(RegressionConfig::default().fail_fast(true))
         .flamegraph(FlamegraphConfig::default());
     library_benchmark_groups = bench_cache_sim);

--- a/benchmark-tests/benches/test_lib_bench/cache_sim/test_lib_bench_cache_sim.rs
+++ b/benchmark-tests/benches/test_lib_bench/cache_sim/test_lib_bench_cache_sim.rs
@@ -15,13 +15,13 @@ fn setup_worst_case_array(start: i32) -> Vec<i32> {
 }
 
 #[library_benchmark(config = LibraryBenchmarkConfig::default().callgrind_args(["--cache-sim=yes"]))]
-#[bench::with_10(setup_worst_case_array(20))]
+#[bench::with_10(setup_worst_case_array(10))]
 fn bench_with_cache_sim(value: Vec<i32>) -> Vec<i32> {
     black_box(bubble_sort(value))
 }
 
 #[library_benchmark(config = LibraryBenchmarkConfig::default().callgrind_args(["--cache-sim=no"]))]
-#[bench::with_10(setup_worst_case_array(20))]
+#[bench::with_10(setup_worst_case_array(10))]
 fn bench_without_cache_sim(value: Vec<i32>) -> Vec<i32> {
     black_box(bubble_sort(value))
 }
@@ -33,6 +33,6 @@ library_benchmark_group!(
 
 main!(
     config = LibraryBenchmarkConfig::default()
-        .regression(RegressionConfig::default().fail_fast(true))
+        .regression(RegressionConfig::default())
         .flamegraph(FlamegraphConfig::default());
     library_benchmark_groups = bench_cache_sim);

--- a/benchmark-tests/benches/test_lib_bench/compare/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/compare/expected_stdout.1
@@ -194,3 +194,5 @@ test_lib_bench_compare::bubble_sort_compare_no_id::bench_bubble_sort_no_id_2
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 20 without regressions; 0 regressed; 20 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.1
@@ -44,3 +44,5 @@ test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_fi
   Estimated Cycles:                        |N/A                  (*********)
 GROUP TEARDOWN
 MAIN TEARDOWN
+
+Iai-Callgrind result: Ok. 5 without regressions; 0 regressed; 5 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.2
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.2
@@ -49,3 +49,5 @@ test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_fi
   Estimated Cycles:                        |N/A                  (*********)
 GROUP TEARDOWN
 MAIN TEARDOWN
+
+Iai-Callgrind result: Ok. 5 without regressions; 0 regressed; 5 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.3
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.3
@@ -38,3 +38,5 @@ test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_fi
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 5 without regressions; 0 regressed; 5 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.1
@@ -12,3 +12,5 @@ test_lib_bench_nocapture::bench_fibonacci_group::bench setup_stderr_teardown_std
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.2
+++ b/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.2
@@ -18,3 +18,5 @@ teardown: stdout: 121
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.3
+++ b/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.3
@@ -18,3 +18,5 @@ teardown: stdout: 121
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.4
+++ b/benchmark-tests/benches/test_lib_bench/nocapture/expected_stdout.4
@@ -14,3 +14,5 @@ test_lib_bench_nocapture::bench_fibonacci_group::bench setup_stderr_teardown_std
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1a
@@ -78,3 +78,5 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |                     (         )
 | Total read+write:                        |                     (-       %) [-       x]
 | Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.1b
@@ -78,3 +78,5 @@ Number of primes found in the range 0 to 30000: 3245
 | RAM Hits:                                |                     (         )
 | Total read+write:                        |                     (-       %) [-       x]
 | Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.no_summary
+++ b/benchmark-tests/benches/test_lib_bench/output_format/expected_stdout.no_summary
@@ -1,0 +1,74 @@
+test_lib_bench_output_format::my_group::bench_without_format for_comparison:"A very long string to see if the truncation of th...
+  ======= CALLGRIND ====================================================================
+  Instructions:                            |N/A                  (*********)
+  L1 Hits:                                 |N/A                  (*********)
+  L2 Hits:                                 |N/A                  (*********)
+  RAM Hits:                                |N/A                  (*********)
+  Total read+write:                        |N/A                  (*********)
+  Estimated Cycles:                        |N/A                  (*********)
+  ======= DHAT =========================================================================
+  Total bytes:                             |N/A                  (*********)
+  Total blocks:                            |N/A                  (*********)
+  At t-gmax bytes:                         |N/A                  (*********)
+  At t-gmax blocks:                        |N/A                  (*********)
+  At t-end bytes:                          |N/A                  (*********)
+  At t-end blocks:                         |N/A                  (*********)
+  Reads bytes:                             |N/A                  (*********)
+  Writes bytes:                            |N/A                  (*********)
+test_lib_bench_output_format::my_group::bench_with_format for_comparison:"Another very long string to see if the truncation is disabled with the formatting option"
+|======== CALLGRIND ====================================================================
+|-## pid: <__PID__> thread: 1 part: 1      |N/A
+| Command: <__COMMAND__>
+| Instructions:                            |N/A                  (*********)
+| L1 Hits:                                 |N/A                  (*********)
+| L2 Hits:                                 |N/A                  (*********)
+| RAM Hits:                                |N/A                  (*********)
+| Total read+write:                        |N/A                  (*********)
+| Estimated Cycles:                        |N/A                  (*********)
+|-## pid: <__PID__> thread: 2 part: 1      |N/A
+| Command: <__COMMAND__>
+| Instructions:                            |N/A                  (*********)
+| L1 Hits:                                 |N/A                  (*********)
+| L2 Hits:                                 |N/A                  (*********)
+| RAM Hits:                                |N/A                  (*********)
+| Total read+write:                        |N/A                  (*********)
+| Estimated Cycles:                        |N/A                  (*********)
+|-## pid: <__PID__> thread: 3 part: 1      |N/A
+| Command: <__COMMAND__>
+| Instructions:                            |N/A                  (*********)
+| L1 Hits:                                 |N/A                  (*********)
+| L2 Hits:                                 |N/A                  (*********)
+| RAM Hits:                                |N/A                  (*********)
+| Total read+write:                        |N/A                  (*********)
+| Estimated Cycles:                        |N/A                  (*********)
+|-## pid: <__PID__> thread: 4 part: 1      |N/A
+| Command: <__COMMAND__>
+| Instructions:                            |N/A                  (*********)
+| L1 Hits:                                 |N/A                  (*********)
+| L2 Hits:                                 |N/A                  (*********)
+| RAM Hits:                                |N/A                  (*********)
+| Total read+write:                        |N/A                  (*********)
+| Estimated Cycles:                        |N/A                  (*********)
+|-## Total
+| Instructions:                            |N/A                  (*********)
+| L1 Hits:                                 |N/A                  (*********)
+| L2 Hits:                                 |N/A                  (*********)
+| RAM Hits:                                |N/A                  (*********)
+| Total read+write:                        |N/A                  (*********)
+| Estimated Cycles:                        |N/A                  (*********)
+|======== DHAT =========================================================================
+| Total bytes:                             |N/A                  (*********)
+| Total blocks:                            |N/A                  (*********)
+| At t-gmax bytes:                         |N/A                  (*********)
+| At t-gmax blocks:                        |N/A                  (*********)
+| At t-end bytes:                          |N/A                  (*********)
+| At t-end blocks:                         |N/A                  (*********)
+| Reads bytes:                             |N/A                  (*********)
+| Writes bytes:                            |N/A                  (*********)
+|-Comparison with bench_without_format for_comparison:"A very long string to see if the truncation of th...
+| Instructions:                            |                     (-       %) [-       x]
+| L1 Hits:                                 |                     (         )
+| L2 Hits:                                 |                     (         )
+| RAM Hits:                                |                     (         )
+| Total read+write:                        |                     (-       %) [-       x]
+| Estimated Cycles:                        |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/output_format/test_lib_bench_output_format.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/output_format/test_lib_bench_output_format.conf.yml
@@ -7,6 +7,11 @@ groups:
       - args: ["--nocapture"]
         expected:
           stdout: expected_stdout.1b
+  - runs_on: "!x86_64-unknown-freebsd"
+    runs:
+      - args: ["--nosummary"]
+        expected:
+          stdout: expected_stdout.no_summary
   - runs_on: "x86_64-unknown-freebsd"
     runs:
       - args: []

--- a/benchmark-tests/benches/test_lib_bench/parts/expected_stdout
+++ b/benchmark-tests/benches/test_lib_bench/parts/expected_stdout
@@ -437,3 +437,5 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 9 without regressions; 0 regressed; 9 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/parts/expected_stdout.1.67.1
+++ b/benchmark-tests/benches/test_lib_bench/parts/expected_stdout.1.67.1
@@ -437,3 +437,5 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 9 without regressions; 0 regressed; 9 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/regression/expected_stderr.fail-fast
+++ b/benchmark-tests/benches/test_lib_bench/regression/expected_stderr.fail-fast
@@ -1,5 +1,5 @@
-Performance has regressed: Instructions (<__NUM__> > <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>)
-iai_callgrind_runner: Error: Performance has regressed. Aborting ...
+Performance has regressed: Instructions (<__NUM__> -> <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>%)
+iai_callgrind_runner: Error: Performance has regressed. Fail-fast is set. Aborting ...
 error: bench failed, to rerun pass `-p benchmark-tests --bench test_bench_template`
 
 Caused by:

--- a/benchmark-tests/benches/test_lib_bench/regression/expected_stderr.no-fail-fast
+++ b/benchmark-tests/benches/test_lib_bench/regression/expected_stderr.no-fail-fast
@@ -1,5 +1,4 @@
-Performance has regressed: Instructions (<__NUM__> > <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>)
-iai_callgrind_runner: Error: Performance has regressed.
+Performance has regressed: Instructions (<__NUM__> -> <__NUM__>) regressed by +<__PERCENT__>% (>+<__NUM__>%)
 error: bench failed, to rerun pass `-p benchmark-tests --bench test_bench_template`
 
 Caused by:

--- a/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.1
@@ -12,3 +12,5 @@ test_bench_template::bench_group::bench_bubble_sort should_not_run_after_regress
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Success. 2 completed without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.1
@@ -13,4 +13,4 @@ test_bench_template::bench_group::bench_bubble_sort should_not_run_after_regress
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
 
-Iai-Callgrind result: Success. 2 completed without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s
+Iai-Callgrind result: Ok. 2 without regressions; 0 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.no-fail-fast
+++ b/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.no-fail-fast
@@ -13,4 +13,9 @@ test_bench_template::bench_group::bench_bubble_sort should_not_run_after_regress
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 
-Iai-Callgrind result: Success. 1 completed without regressions; 1 regressed; 2 benchmarks finished in <__SECONDS__>s
+Regressions:
+
+  test_bench_template::bench_group::bench_bubble_sort regress_ir:
+    Instructions (<__NUM__> -> <__NUM__>): +<__PERCENT__>% exceeds limit of +<__PERCENT__>%
+
+Iai-Callgrind result: Regressed. 1 without regressions; 1 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.no-fail-fast
+++ b/benchmark-tests/benches/test_lib_bench/regression/expected_stdout.no-fail-fast
@@ -12,3 +12,5 @@ test_bench_template::bench_group::bench_bubble_sort should_not_run_after_regress
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Success. 1 completed without regressions; 1 regressed; 2 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/single/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/single/expected_stdout.1
@@ -6,3 +6,5 @@ test_bench_template::bench_group::bench_bubble_sort worst_case:setup_worst_case_
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/single/expected_stdout.2
+++ b/benchmark-tests/benches/test_lib_bench/single/expected_stdout.2
@@ -6,3 +6,5 @@ test_bench_template::bench_group::bench_bubble_sort worst_case:setup_worst_case_
   RAM Hits:                                |N/A                  (*********)
   Total read+write:                        |N/A                  (*********)
   Estimated Cycles:                        |N/A                  (*********)
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/single/expected_stdout.3
+++ b/benchmark-tests/benches/test_lib_bench/single/expected_stdout.3
@@ -6,3 +6,5 @@ test_bench_template::bench_group::bench_bubble_sort worst_case:setup_worst_case_
   RAM Hits:                                |                     (         )
   Total read+write:                        |                     (+       %) [+       x]
   Estimated Cycles:                        |                     (         )
+
+Iai-Callgrind result: Ok. 1 without regressions; 0 regressed; 1 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1a
@@ -568,3 +568,4 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   ## pid: <__PID__> ppid: <__PID__>        |N/A
   Command:             target/release/thread --thread-in-thread
   Details: <__DETAILS__>
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1b
@@ -568,3 +568,4 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   ## pid: <__PID__> ppid: <__PID__>        |pid: <__PID__> ppid: <__PID__>
   Command:             target/release/thread --thread-in-thread
   Details: <__DETAILS__>
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1d
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1d
@@ -574,3 +574,4 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   ## pid: <__PID__> ppid: <__PID__>        |N/A
   Command:             target/release/thread --thread-in-thread
   Details: <__DETAILS__>
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1e
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1e
@@ -574,3 +574,4 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   ## pid: <__PID__> ppid: <__PID__>        |N/A
   Command:             target/release/thread --thread-in-thread
   Details: <__DETAILS__>
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1f
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1f
@@ -562,3 +562,4 @@ test_lib_bench_threads::bench_group::bench_thread_in_thread_in_subprocess
   ## pid: <__PID__> ppid: <__PID__>        |pid: <__PID__> ppid: <__PID__>
   Command:             target/release/thread --thread-in-thread
   Details: <__DETAILS__>
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1g
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1g
@@ -574,3 +574,4 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   ## pid: <__PID__> ppid: <__PID__>        |pid: <__PID__> ppid: <__PID__>
   Command:             target/release/thread --thread-in-thread
   Details: <__DETAILS__>
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.freebsd.1a
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.freebsd.1a
@@ -571,3 +571,4 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
   ## pid: <__PID__> ppid: <__PID__>        |N/A
   Command:             target/release/thread --thread-in-thread
   Details: <__DETAILS__>
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1a
+++ b/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1a
@@ -299,3 +299,5 @@ test_lib_bench_tools::bench_group::bad_memory
   Suppressed Contexts:                     |N/A                  (*********)
   ======= MASSIF =======================================================================
   Command: <__COMMAND__>
+
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1b
+++ b/benchmark-tests/benches/test_lib_bench/tools/expected_stdout.1b
@@ -291,3 +291,5 @@ test_lib_bench_tools::bench_group::bad_memory
   Suppressed Contexts:                     |                     (         )
   ======= MASSIF =======================================================================
   Command: <__COMMAND__>
+
+Iai-Callgrind result: Ok. 6 without regressions; 0 regressed; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -68,6 +68,9 @@ lazy_static! {
         Regex::new(r"^(##(?: \S+: \S+)+)(\s*)([|].*)$").expect("Regex should compile");
     static ref ABSOLUTE_PATH_RE: Regex =
         Regex::new(r"(\s+)([/][^/]*)+").expect("Regex should compile");
+    // Iai-Callgrind result: Success. 2 completed without regressions; 0 regressed; 2 benchmarks finished in 0.296s
+    static ref SUMMARY_LINE_RE: Regex =
+        Regex::new(r"^(Iai-Callgrind result:.*finished in\s*)([0-9.]+)(s)$").expect("Regex should compile");
 }
 
 #[derive(Debug, Clone)]
@@ -677,6 +680,7 @@ impl BenchmarkOutput {
                         format!("{caps_1} {caps_3}")
                     }
                 });
+                let line = SUMMARY_LINE_RE.replace_all(&line, "$1<__SECONDS__>$3");
                 writeln!(result, "{indent}{line}").unwrap();
             }
         }

--- a/iai-callgrind-runner/src/error.rs
+++ b/iai-callgrind-runner/src/error.rs
@@ -100,7 +100,10 @@ impl Display for Error {
             }
             Self::RegressionError(is_fatal) => {
                 if *is_fatal {
-                    write!(f, "Performance has regressed. Aborting ...",)
+                    write!(
+                        f,
+                        "Performance has regressed. Fail-fast is set. Aborting ...",
+                    )
                 } else {
                     write!(f, "Performance has regressed.",)
                 }

--- a/iai-callgrind-runner/src/main.rs
+++ b/iai-callgrind-runner/src/main.rs
@@ -76,6 +76,7 @@ fn main() {
                 warn!("{error}");
                 std::process::exit(0)
             }
+            Some(Error::RegressionError(false)) => std::process::exit(1),
             _ => {
                 error!("{error}");
                 std::process::exit(1)

--- a/iai-callgrind-runner/src/runner/args.rs
+++ b/iai-callgrind-runner/src/runner/args.rs
@@ -361,6 +361,24 @@ pub struct CommandLineArgs {
         env = "IAI_CALLGRIND_LIST"
     )]
     pub list: bool,
+
+    /// Suppress the summary showing regressions and execution time at the end of a benchmark run
+    ///
+    /// Note, that a summary is only printed if the `--output-format` is not JSON.
+    ///
+    /// The summary described by `--nosummary` is different from `--save-summary` and they do not
+    /// affect each other.
+    #[arg(
+        long = "nosummary",
+        default_missing_value = "true",
+        default_value = "false",
+        num_args = 0..=1,
+        require_equals = true,
+        value_parser = BoolishValueParser::new(),
+        action = ArgAction::Set,
+        env = "IAI_CALLGRIND_NOSUMMARY"
+    )]
+    pub nosummary: bool,
 }
 
 /// This function parses a space separated list of raw argument strings into [`crate::api::RawArgs`]

--- a/iai-callgrind-runner/src/runner/bin_bench.rs
+++ b/iai-callgrind-runner/src/runner/bin_bench.rs
@@ -629,12 +629,7 @@ impl Delay {
 }
 
 impl Group {
-    fn run(
-        &self,
-        benchmark: &dyn Benchmark,
-        is_regressed: &mut bool,
-        config: &Config,
-    ) -> Result<BenchmarkSummaries> {
+    fn run(&self, benchmark: &dyn Benchmark, config: &Config) -> Result<BenchmarkSummaries> {
         let mut benchmark_summaries = BenchmarkSummaries::default();
 
         let mut summaries: HashMap<String, Vec<BenchmarkSummary>> =
@@ -647,9 +642,8 @@ impl Group {
 
             let summary = benchmark.run(bench, config, self)?;
             summary.print_and_save(&config.meta.args.output_format)?;
-            summary.check_regression(is_regressed, fail_fast)?;
+            summary.check_regression(fail_fast)?;
 
-            // TODO: could be a Cow? also in lib_bench
             benchmark_summaries.add_summary(summary.clone());
             if self.compare_by_id && bench.output_format.is_default() {
                 if let Some(id) = &summary.id {
@@ -760,7 +754,7 @@ impl Groups {
                 setup.run(config, &group.module_path)?;
             }
 
-            let summaries = group.run(benchmark, &mut false, config)?;
+            let summaries = group.run(benchmark, config)?;
 
             if let Some(teardown) = &group.teardown {
                 teardown.run(config, &group.module_path)?;

--- a/iai-callgrind-runner/src/runner/bin_bench.rs
+++ b/iai-callgrind-runner/src/runner/bin_bench.rs
@@ -5,7 +5,7 @@ use std::io::ErrorKind::WouldBlock;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, RecvTimeoutError};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{panic, thread};
 
 use anyhow::{anyhow, Context, Result};
@@ -20,7 +20,7 @@ use super::callgrind::flamegraph::{
 use super::callgrind::parser::CallgrindParser;
 use super::callgrind::summary_parser::SummaryParser;
 use super::callgrind::{RegressionConfig, Summaries};
-use super::common::{Assistant, AssistantKind, Config, ModulePath, Sandbox};
+use super::common::{Assistant, AssistantKind, BenchmarkSummaries, Config, ModulePath, Sandbox};
 use super::format::{BinaryBenchmarkHeader, Formatter, OutputFormat, VerticalFormatter};
 use super::meta::Metadata;
 use super::summary::{
@@ -34,7 +34,6 @@ use super::tool::{
 use crate::api::{
     self, BinaryBenchmarkBench, BinaryBenchmarkConfig, BinaryBenchmarkGroups, DelayKind, Stdin,
 };
-use crate::error::Error;
 use crate::runner::format;
 
 mod defaults {
@@ -635,7 +634,9 @@ impl Group {
         benchmark: &dyn Benchmark,
         is_regressed: &mut bool,
         config: &Config,
-    ) -> Result<()> {
+    ) -> Result<BenchmarkSummaries> {
+        let mut benchmark_summaries = BenchmarkSummaries::default();
+
         let mut summaries: HashMap<String, Vec<BenchmarkSummary>> =
             HashMap::with_capacity(self.benches.len());
         for bench in &self.benches {
@@ -648,6 +649,8 @@ impl Group {
             summary.print_and_save(&config.meta.args.output_format)?;
             summary.check_regression(is_regressed, fail_fast)?;
 
+            // TODO: could be a Cow? also in lib_bench
+            benchmark_summaries.add_summary(summary.clone());
             if self.compare_by_id && bench.output_format.is_default() {
                 if let Some(id) = &summary.id {
                     if let Some(sums) = summaries.get_mut(id) {
@@ -662,7 +665,7 @@ impl Group {
             }
         }
 
-        Ok(())
+        Ok(benchmark_summaries)
     }
 }
 
@@ -750,25 +753,23 @@ impl Groups {
     /// Return an [`anyhow::Error`] with sources:
     ///
     /// * [`Error::RegressionError`] if a regression occurred.
-    fn run(&self, benchmark: &dyn Benchmark, config: &Config) -> Result<()> {
-        let mut is_regressed = false;
+    fn run(&self, benchmark: &dyn Benchmark, config: &Config) -> Result<BenchmarkSummaries> {
+        let mut benchmark_summaries = BenchmarkSummaries::default();
         for group in &self.0 {
             if let Some(setup) = &group.setup {
                 setup.run(config, &group.module_path)?;
             }
 
-            group.run(benchmark, &mut is_regressed, config)?;
+            let summaries = group.run(benchmark, &mut false, config)?;
 
             if let Some(teardown) = &group.teardown {
                 teardown.run(config, &group.module_path)?;
             }
+
+            benchmark_summaries.add_other(summaries);
         }
 
-        if is_regressed {
-            Err(Error::RegressionError(false).into())
-        } else {
-            Ok(())
-        }
+        Ok(benchmark_summaries)
     }
 }
 
@@ -916,17 +917,18 @@ impl Runner {
         })
     }
 
-    fn run(&self) -> Result<()> {
+    fn run(&self) -> Result<BenchmarkSummaries> {
         if let Some(setup) = &self.setup {
             setup.run(&self.config, &self.config.module_path)?;
         }
 
-        self.groups.run(self.benchmark.as_ref(), &self.config)?;
+        let summaries = self.groups.run(self.benchmark.as_ref(), &self.config)?;
 
         if let Some(teardown) = &self.teardown {
             teardown.run(&self.config, &self.config.module_path)?;
         }
-        Ok(())
+
+        Ok(summaries)
     }
 }
 
@@ -1093,8 +1095,14 @@ impl Benchmark for SaveBaselineBenchmark {
     }
 }
 
-pub fn run(benchmark_groups: BinaryBenchmarkGroups, config: Config) -> Result<()> {
-    Runner::new(benchmark_groups, config)?.run()
+pub fn run(benchmark_groups: BinaryBenchmarkGroups, config: Config) -> Result<BenchmarkSummaries> {
+    let runner = Runner::new(benchmark_groups, config)?;
+
+    let start = Instant::now();
+    let mut summaries = runner.run()?;
+    summaries.elapsed(start);
+
+    Ok(summaries)
 }
 
 /// Print a list of all benchmarks with a short summary

--- a/iai-callgrind-runner/src/runner/callgrind/mod.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/mod.rs
@@ -110,6 +110,7 @@ impl RegressionConfig {
             limit,
         } in &regression
         {
+            // TODO: THE REGRESSION SHOULD LOOK THE SAME AS THE ONE IN THE SUMMARY
             if limit.is_sign_positive() {
                 eprintln!(
                     "Performance has {0}: {1} ({new} > {old}) regressed by {2:>+6} (>{3:>+6})",

--- a/iai-callgrind-runner/src/runner/callgrind/mod.rs
+++ b/iai-callgrind-runner/src/runner/callgrind/mod.rs
@@ -110,26 +110,27 @@ impl RegressionConfig {
             limit,
         } in &regression
         {
-            // TODO: THE REGRESSION SHOULD LOOK THE SAME AS THE ONE IN THE SUMMARY
             if limit.is_sign_positive() {
                 eprintln!(
-                    "Performance has {0}: {1} ({new} > {old}) regressed by {2:>+6} (>{3:>+6})",
+                    "Performance has {0}: {1} ({old} -> {2}) regressed by {3:>+6} (>{4:>+6})",
                     "regressed".bold().bright_red(),
                     event_kind.to_string().bold(),
+                    new.to_string().bold(),
                     format!("{}%", to_string_signed_short(*diff_pct))
                         .bold()
                         .bright_red(),
-                    to_string_signed_short(*limit).bright_black()
+                    format!("{}%", to_string_signed_short(*limit)).bright_black()
                 );
             } else {
                 eprintln!(
-                    "Performance has {0}: {1} ({new} < {old}) regressed by {2:>+6} (<{3:>+6})",
+                    "Performance has {0}: {1} ({old} -> {2}) regressed by {3:>+6} (<{4:>+6})",
                     "regressed".bold().bright_red(),
                     event_kind.to_string().bold(),
+                    new.to_string().bold(),
                     format!("{}%", to_string_signed_short(*diff_pct))
                         .bold()
                         .bright_red(),
-                    to_string_signed_short(*limit).bright_black()
+                    format!("{}%", to_string_signed_short(*limit)).bright_black()
                 );
             }
         }

--- a/iai-callgrind-runner/src/runner/common.rs
+++ b/iai-callgrind-runner/src/runner/common.rs
@@ -234,30 +234,43 @@ impl AssistantKind {
 }
 
 impl BenchmarkSummaries {
+    /// Add a [`BenchmarkSummary`]
     pub fn add_summary(&mut self, summary: BenchmarkSummary) {
         self.summaries.push(summary);
     }
 
+    /// Add another `BenchmarkSummary`
+    ///
+    /// Ignores the execution time.
     pub fn add_other(&mut self, other: Self) {
         other.summaries.into_iter().for_each(|s| {
             self.add_summary(s);
         });
     }
 
+    /// Return true if any regressions were encountered
     pub fn is_regressed(&self) -> bool {
         self.summaries.iter().any(BenchmarkSummary::is_regressed)
     }
 
+    /// Set the total execution from `start` to `now`
     pub fn elapsed(&mut self, start: Instant) {
         self.total_time = Some(start.elapsed());
     }
 
+    /// Return the number of total benchmarks
     pub fn num_benchmarks(&self) -> usize {
         self.summaries.len()
     }
 
-    pub fn print(&self, output_format_kind: OutputFormatKind) {
-        SummaryFormatter::new(output_format_kind).print(self);
+    /// Print the summary if not prevented by command-line arguments
+    ///
+    /// If `nosummary` is true or [`OutputFormatKind`] is any kind of `JSON` format the summary is
+    /// not printed.
+    pub fn print(&self, nosummary: bool, output_format_kind: OutputFormatKind) {
+        if !nosummary {
+            SummaryFormatter::new(output_format_kind).print(self);
+        }
     }
 }
 

--- a/iai-callgrind-runner/src/runner/common.rs
+++ b/iai-callgrind-runner/src/runner/common.rs
@@ -37,40 +37,15 @@ pub enum AssistantKind {
     Teardown,
 }
 
-/// TODO: DOCS
+/// Contains benchmark summaries of (binary, library) benchmark runs and their execution time
+///
+/// Used to print a final summary after all benchmarks.
 #[derive(Debug, Default)]
 pub struct BenchmarkSummaries {
+    /// The benchmark summaries
     pub summaries: Vec<BenchmarkSummary>,
+    /// The execution time of all benchmarks.
     pub total_time: Option<Duration>,
-}
-
-// TODO: SORT
-impl BenchmarkSummaries {
-    pub fn add_summary(&mut self, summary: BenchmarkSummary) {
-        self.summaries.push(summary);
-    }
-
-    pub fn add_other(&mut self, other: Self) {
-        other.summaries.into_iter().for_each(|s| {
-            self.add_summary(s);
-        });
-    }
-
-    pub fn is_regressed(&self) -> bool {
-        self.summaries.iter().any(BenchmarkSummary::is_regressed)
-    }
-
-    pub fn elapsed(&mut self, start: Instant) {
-        self.total_time = Some(start.elapsed());
-    }
-
-    pub fn num_benchmarks(&self) -> usize {
-        self.summaries.len()
-    }
-
-    pub fn print(&self, output_format_kind: OutputFormatKind) {
-        SummaryFormatter::new(output_format_kind).print(self);
-    }
 }
 
 #[derive(Debug)]
@@ -255,6 +230,34 @@ impl AssistantKind {
             AssistantKind::Teardown => "teardown",
         }
         .to_owned()
+    }
+}
+
+impl BenchmarkSummaries {
+    pub fn add_summary(&mut self, summary: BenchmarkSummary) {
+        self.summaries.push(summary);
+    }
+
+    pub fn add_other(&mut self, other: Self) {
+        other.summaries.into_iter().for_each(|s| {
+            self.add_summary(s);
+        });
+    }
+
+    pub fn is_regressed(&self) -> bool {
+        self.summaries.iter().any(BenchmarkSummary::is_regressed)
+    }
+
+    pub fn elapsed(&mut self, start: Instant) {
+        self.total_time = Some(start.elapsed());
+    }
+
+    pub fn num_benchmarks(&self) -> usize {
+        self.summaries.len()
+    }
+
+    pub fn print(&self, output_format_kind: OutputFormatKind) {
+        SummaryFormatter::new(output_format_kind).print(self);
     }
 }
 

--- a/iai-callgrind-runner/src/runner/format.rs
+++ b/iai-callgrind-runner/src/runner/format.rs
@@ -487,7 +487,7 @@ impl SummaryFormatter {
                     "\nIai-Callgrind result: {}. {num_not_regressed} without regressions; \
                      {num_regressed} regressed; {total_benchmarks} benchmarks finished in \
                      {total_time:>6}s",
-                    "Regressed".red().bold(),
+                    "Regressed".bright_red().bold(),
                 );
             } else {
                 println!(

--- a/iai-callgrind-runner/src/runner/lib_bench.rs
+++ b/iai-callgrind-runner/src/runner/lib_bench.rs
@@ -412,7 +412,7 @@ impl Groups {
 
                 let lib_bench_summary = benchmark.run(bench, config, group)?;
                 lib_bench_summary.print_and_save(&config.meta.args.output_format)?;
-                lib_bench_summary.check_regression(&mut false, fail_fast)?;
+                lib_bench_summary.check_regression(fail_fast)?;
 
                 benchmark_summaries.add_summary(lib_bench_summary.clone());
                 if group.compare_by_id && bench.output_format.is_default() {

--- a/iai-callgrind-runner/src/runner/mod.rs
+++ b/iai-callgrind-runner/src/runner/mod.rs
@@ -16,7 +16,9 @@ use std::io::{stdin, Read};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use common::{Config, ModulePath};
+use args::CommandLineArgs;
+use common::{BenchmarkSummaries, Config, ModulePath};
+use format::OutputFormatKind;
 use log::debug;
 
 use self::meta::Metadata;
@@ -35,6 +37,17 @@ pub mod envs {
 
 pub const DEFAULT_TOGGLE: &str = "*::__iai_callgrind_wrapper_mod::*";
 
+/// Execute post benchmark run actions like printing the summary line with regressions
+#[derive(Debug)]
+struct PostRun {
+    benchmark_summaries: Option<BenchmarkSummaries>,
+    nosummary: bool,
+    output_format_kind: OutputFormatKind,
+}
+
+/// The arguments sent by the iai-callgrind benchmarking harness
+///
+/// These are not the user arguments of the `cargo bench ... -- ARGS` command.
 #[derive(Debug)]
 struct RunnerArgs {
     bench_kind: BenchmarkKind,
@@ -47,6 +60,40 @@ struct RunnerArgs {
 }
 
 struct RunnerArgsIterator(ArgsOs);
+
+impl PostRun {
+    /// Create a new `PostRun`
+    fn new(nosummary: bool, output_format_kind: OutputFormatKind) -> Self {
+        Self {
+            benchmark_summaries: None,
+            nosummary,
+            output_format_kind,
+        }
+    }
+
+    /// Builder method to add the [`BenchmarkSummaries`] and return `Self`
+    fn summaries(mut self, benchmark_summaries: BenchmarkSummaries) -> Self {
+        self.benchmark_summaries = Some(benchmark_summaries);
+        self
+    }
+
+    /// Print the summary returning [`Error::RegressionError`] if regressions were present
+    ///
+    /// The summary is not printed if `nosummary` is true or the [`OutputFormatKind`] is not the
+    /// default format (i.e. JSON).
+    fn execute(self) -> Result<()> {
+        let summaries = self
+            .benchmark_summaries
+            .expect("The benchmark summaries should be available");
+
+        summaries.print(self.nosummary, self.output_format_kind);
+        if summaries.is_regressed() {
+            Err(Error::RegressionError(false).into())
+        } else {
+            Ok(())
+        }
+    }
+}
 
 impl RunnerArgs {
     fn new() -> Result<Self> {
@@ -182,7 +229,7 @@ pub fn run() -> Result<()> {
         num_bytes,
     } = RunnerArgs::new()?;
 
-    let (summaries, output_format_kind) = match bench_kind {
+    let post_run = match bench_kind {
         BenchmarkKind::LibraryBenchmark => {
             let benchmark_groups: LibraryBenchmarkGroups = receive_benchmark(num_bytes)?;
             let meta = Metadata::new(
@@ -208,12 +255,19 @@ pub fn run() -> Result<()> {
                 meta,
             };
 
-            if config.meta.args.list {
+            let CommandLineArgs {
+                output_format,
+                list,
+                nosummary,
+                ..
+            } = config.meta.args;
+
+            if list {
                 return lib_bench::list(benchmark_groups, &config);
             }
 
-            let output_format_kind = config.meta.args.output_format;
-            lib_bench::run(benchmark_groups, config).map(|s| (s, output_format_kind))?
+            lib_bench::run(benchmark_groups, config)
+                .map(|s| PostRun::new(nosummary, output_format).summaries(s))?
         }
         BenchmarkKind::BinaryBenchmark => {
             let benchmark_groups: BinaryBenchmarkGroups = receive_benchmark(num_bytes)?;
@@ -240,19 +294,21 @@ pub fn run() -> Result<()> {
                 meta,
             };
 
-            if config.meta.args.list {
+            let CommandLineArgs {
+                output_format,
+                list,
+                nosummary,
+                ..
+            } = config.meta.args;
+
+            if list {
                 return bin_bench::list(benchmark_groups, &config);
             }
 
-            let output_format_kind = config.meta.args.output_format;
-            bin_bench::run(benchmark_groups, config).map(|s| (s, output_format_kind))?
+            bin_bench::run(benchmark_groups, config)
+                .map(|s| PostRun::new(nosummary, output_format).summaries(s))?
         }
     };
 
-    summaries.print(output_format_kind);
-    if summaries.is_regressed() {
-        Err(Error::RegressionError(false).into())
-    } else {
-        Ok(())
-    }
+    post_run.execute()
 }

--- a/iai-callgrind-runner/src/runner/summary.rs
+++ b/iai-callgrind-runner/src/runner/summary.rs
@@ -459,21 +459,16 @@ impl BenchmarkSummary {
     /// # Errors
     ///
     /// If the regressions are configured to be `fail_fast` an error is returned
-    /// TODO: REMOVE `is_regressed`
-    pub fn check_regression(&self, is_regressed: &mut bool, fail_fast: bool) -> Result<()> {
+    pub fn check_regression(&self, fail_fast: bool) -> Result<()> {
         if let Some(callgrind_summary) = &self.callgrind_summary {
-            let benchmark_is_regressed = callgrind_summary.is_regressed();
-            if benchmark_is_regressed && fail_fast {
+            if callgrind_summary.is_regressed() && fail_fast {
                 return Err(Error::RegressionError(true).into());
             }
-
-            *is_regressed |= benchmark_is_regressed;
         }
 
         Ok(())
     }
 
-    /// TODO: DOCS
     pub fn is_regressed(&self) -> bool {
         self.callgrind_summary
             .as_ref()

--- a/iai-callgrind-runner/src/util.rs
+++ b/iai-callgrind-runner/src/util.rs
@@ -260,6 +260,13 @@ pub fn to_string_signed_short(n: f64) -> String {
     }
 }
 
+/// Format a float as string depending on the number of digits of the integer-part without sign
+///
+/// Same as [`to_string_signed_short`] but without a sign.
+pub fn to_string_unsigned_short(n: f64) -> String {
+    to_string_signed_short(n)[1..].to_owned()
+}
+
 /// Calculate the difference between `new` and `old` as percentage
 pub fn percentage_diff(new: u64, old: u64) -> f64 {
     if new == old {


### PR DESCRIPTION
A short showcase of the format with regressions:

```
test_lib_bench_cache_sim::bench_cache_sim::bench_with_cache_sim with_10:setup_worst_case_array(20)
  Baselines:                               |default
  Instructions:                        2820|720                  (+291.667%) [+3.91667x]
  L1 Hits:                             3594|914                  (+293.217%) [+3.93217x]
  L2 Hits:                                0|0                    (No change)
  RAM Hits:                               4|4                    (No change)
  Total read+write:                    3598|918                  (+291.939%) [+3.91939x]
  Estimated Cycles:                    3734|1054                 (+254.269%) [+3.54269x]
Performance has regressed: Instructions (720 -> 2820) regressed by +291.667% (>+10.0000%)
test_lib_bench_cache_sim::bench_cache_sim::bench_without_cache_sim with_10:setup_worst_case_array(20)
  Baselines:                               |default
  Instructions:                        2820|720                  (+291.667%) [+3.91667x]
Performance has regressed: Instructions (720 -> 2820) regressed by +291.667% (>+10.0000%)

Regressions:

  test_lib_bench_cache_sim::bench_cache_sim::bench_with_cache_sim with_10:
    Instructions (720 -> 2820): +291.667% exceeds limit of +10.0000%
  test_lib_bench_cache_sim::bench_cache_sim::bench_without_cache_sim with_10:
    Instructions (720 -> 2820): +291.667% exceeds limit of +10.0000%

Iai-Callgrind result: Regressed. 0 without regressions; 2 regressed; 2 benchmarks finished in 0.28407s
```

The summary is not printed if `fail-fast` for regression checks was set to true. 

This pr also introduces a new command-line argument `--nosummary` to be able to suppress printing the summary. The summary is also not printed if the `--output-format` is Json to allow parsing the stdout for example with `jq`.

Closes #356 