### PR TITLE
refactor(format): use ': benchmark' suffix

### DIFF
--- a/benchmark-tests/benches/test_bin_bench/list_arg/expected_stdout
+++ b/benchmark-tests/benches/test_bin_bench/list_arg/expected_stdout
@@ -1,5 +1,5 @@
-test_bin_bench_list_arg::group_1::echo_bench: bench
-test_bin_bench_list_arg::group_2::read_file_bench: bench
-test_bin_bench_list_arg::group_2::echo_bench: bench
+test_bin_bench_list_arg::group_1::echo_bench: benchmark
+test_bin_bench_list_arg::group_2::read_file_bench: benchmark
+test_bin_bench_list_arg::group_2::echo_bench: benchmark
 
 0 tests, 3 benchmarks

--- a/benchmark-tests/benches/test_lib_bench/list_arg/expected_stdout
+++ b/benchmark-tests/benches/test_lib_bench/list_arg/expected_stdout
@@ -1,5 +1,5 @@
-test_lib_bench_list_arg::group_1::minimal_bench: bench
-test_lib_bench_list_arg::group_2::other_bench: bench
-test_lib_bench_list_arg::group_2::minimal_bench: bench
+test_lib_bench_list_arg::group_1::minimal_bench: benchmark
+test_lib_bench_list_arg::group_2::other_bench: benchmark
+test_lib_bench_list_arg::group_2::minimal_bench: benchmark
 
 0 tests, 3 benchmarks

--- a/iai-callgrind-runner/src/runner/format.rs
+++ b/iai-callgrind-runner/src/runner/format.rs
@@ -1010,10 +1010,10 @@ pub fn print_no_capture_footer(
 pub fn print_list_benchmark(module_path: &ModulePath, id: Option<&String>) {
     match id {
         Some(id) => {
-            println!("{module_path}::{id}: bench");
+            println!("{module_path}::{id}: benchmark");
         }
         None => {
-            println!("{module_path}: bench");
+            println!("{module_path}: benchmark");
         }
     }
 }


### PR DESCRIPTION
Right now `iai_callgrind_runner` outputs the tests using the *non-standard* `: bench`, causing it to be incompatible with third-party testing frameworks (i.e `cargo-nextest`: https://github.com/nextest-rs/nextest/pull/2374).

This changes the suffix to the one recommended by  cargo testing.