### PR TITLE
feat(wrap): Wrap long lines in --help output for better readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1657,6 +1658,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/iai-callgrind-runner/Cargo.toml
+++ b/iai-callgrind-runner/Cargo.toml
@@ -53,7 +53,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 anyhow = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
 cargo_metadata = { workspace = true, optional = true }
-clap = { workspace = true, optional = true, features = ["derive", "env"] }
+clap = { workspace = true, optional = true, features = [
+  "derive",
+  "env",
+  "wrap_help",
+] }
 colored = { workspace = true, optional = true }
 derive_more = { workspace = true, optional = true, features = ["as_ref"] }
 env_logger = { workspace = true, optional = true }

--- a/iai-callgrind-runner/src/runner/args.rs
+++ b/iai-callgrind-runner/src/runner/args.rs
@@ -151,8 +151,7 @@ pub struct CommandLineArgs {
 
     /// The raw arguments to pass through to Callgrind
     ///
-    /// This is a space separated list of command-line-arguments specified as if they were
-    /// passed directly to valgrind.
+    /// List of command-line-arguments specified as if they were passed directly to valgrind.
     ///
     /// Examples:
     ///   * --callgrind-args=--dump-instr=yes

--- a/iai-callgrind-runner/src/runner/args.rs
+++ b/iai-callgrind-runner/src/runner/args.rs
@@ -76,7 +76,8 @@ instead of `true` and one of `n`, `no`, `f`, `false`, `off`, and `0` instead of
 `false`",
     long_about = None,
     no_binary_name = true,
-    override_usage= "cargo bench ... [BENCHNAME] -- [OPTIONS]"
+    override_usage= "cargo bench ... [BENCHNAME] -- [OPTIONS]",
+    max_term_width = 100
 )]
 pub struct CommandLineArgs {
     /// The following arguments are accepted by the rust libtest harness and ignored by us


### PR DESCRIPTION
The --help output is now limited to 100 bytes terminal width.