### PR TITLE
docs: Update and improve guide

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -202,6 +202,7 @@ splitn
 sploss1
 sploss2
 srcloc
+stdlib
 struct
 structifying
 structs

--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -275,3 +275,8 @@ path = "benches/guide/lib_bench_threads.rs"
 harness = false
 name = "lib_bench_subprocess"
 path = "benches/guide/lib_bench_subprocess.rs"
+
+[[bench]]
+harness = false
+name = "lib_bench_regression"
+path = "benches/guide/lib_bench_regression.rs"

--- a/benchmark-tests/benches/guide/lib_bench_regression.rs
+++ b/benchmark-tests/benches/guide/lib_bench_regression.rs
@@ -1,0 +1,24 @@
+use std::hint::black_box;
+
+use benchmark_tests as my_lib;
+use iai_callgrind::{
+    library_benchmark, library_benchmark_group, main, EventKind, LibraryBenchmarkConfig,
+    RegressionConfig,
+};
+
+#[library_benchmark]
+#[bench::worst_case(vec![3, 2, 1])]
+fn bench_library(data: Vec<i32>) -> Vec<i32> {
+    black_box(my_lib::bubble_sort(data))
+}
+
+library_benchmark_group!(name = my_group; benchmarks = bench_library);
+
+main!(
+    config = LibraryBenchmarkConfig::default()
+        .regression(
+            RegressionConfig::default()
+                .limits([(EventKind::Ir, 5.0)])
+        );
+    library_benchmark_groups = my_group
+);

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,6 +22,7 @@
     - [Generic benchmark functions](./benchmarks/library_benchmarks/generic.md)
     - [Comparing benchmark functions](./benchmarks/library_benchmarks/compare_by_id.md)
     - [Configuration](./benchmarks/library_benchmarks/configuration.md)
+        - [Output Format/Cache Misses](./benchmarks/library_benchmarks/configuration/output_format.md)
     - [Custom entry points](./benchmarks/library_benchmarks/custom_entry_point.md)
     - [Multi-threaded and multi-process applications](./benchmarks/library_benchmarks/threads_and_subprocesses.md)
     - [More Examples, please!](./benchmarks/library_benchmarks/examples.md)

--- a/docs/src/benchmarks/binary_benchmarks/important.md
+++ b/docs/src/benchmarks/binary_benchmarks/important.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 MD033 -->
+
 # Important default behaviour
 
 As in library benchmarks, the environment variables are cleared before running a
@@ -46,3 +48,23 @@ main!(
 );
 # }
 ```
+
+<!-- TODO: ALSO IN library_benchmarks -->
+<!-- TODO: Update all example outputs with the summary -->
+<!-- TODO: Talk about --nosummary in cli_and_env -->
+Per default, Iai-Callgrind reports the cache hits and an estimation of cpu
+cycles:
+
+<pre><code class="hljs"><span style="color:#0A0">test_lib_bench_readme_example_fibonacci::bench_fibonacci_group::bench_fibonacci</span> <span style="color:#0AA">short</span><span style="color:#0AA">:</span><b><span style="color:#00A">10</span></b>
+<span style="color:#555">  </span>Instructions:                        <b>1734</b>|1734                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L1 Hits:                             <b>2359</b>|2359                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L2 Hits:                                <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>RAM Hits:                               <b>3</b>|3                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Total read+write:                    <b>2362</b>|2362                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Estimated Cycles:                    <b>2464</b>|2464                 (<span style="color:#555">No change</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
+
+If you prefer cache misses over cache hits or just want both metrics displayed
+you can fully customize the [callgrind output
+format](../library_benchmarks/configuration/output_format.md).

--- a/docs/src/benchmarks/binary_benchmarks/important.md
+++ b/docs/src/benchmarks/binary_benchmarks/important.md
@@ -48,23 +48,3 @@ main!(
 );
 # }
 ```
-
-<!-- TODO: ALSO IN library_benchmarks -->
-<!-- TODO: Update all example outputs with the summary -->
-<!-- TODO: Talk about --nosummary in cli_and_env -->
-Per default, Iai-Callgrind reports the cache hits and an estimation of cpu
-cycles:
-
-<pre><code class="hljs"><span style="color:#0A0">test_lib_bench_readme_example_fibonacci::bench_fibonacci_group::bench_fibonacci</span> <span style="color:#0AA">short</span><span style="color:#0AA">:</span><b><span style="color:#00A">10</span></b>
-<span style="color:#555">  </span>Instructions:                        <b>1734</b>|1734                 (<span style="color:#555">No change</span>)
-<span style="color:#555">  </span>L1 Hits:                             <b>2359</b>|2359                 (<span style="color:#555">No change</span>)
-<span style="color:#555">  </span>L2 Hits:                                <b>0</b>|0                    (<span style="color:#555">No change</span>)
-<span style="color:#555">  </span>RAM Hits:                               <b>3</b>|3                    (<span style="color:#555">No change</span>)
-<span style="color:#555">  </span>Total read+write:                    <b>2362</b>|2362                 (<span style="color:#555">No change</span>)
-<span style="color:#555">  </span>Estimated Cycles:                    <b>2464</b>|2464                 (<span style="color:#555">No change</span>)
-
-Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
-
-If you prefer cache misses over cache hits or just want both metrics displayed
-you can fully customize the [callgrind output
-format](../library_benchmarks/configuration/output_format.md).

--- a/docs/src/benchmarks/binary_benchmarks/quickstart.md
+++ b/docs/src/benchmarks/binary_benchmarks/quickstart.md
@@ -35,7 +35,7 @@ crate.
 
 Note the `env!` macro is a [rust](https://doc.rust-lang.org/std/macro.env.html)
 builtin macro and `CARGO_BIN_EXE_<name>` is documented
-[here](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates).
+[rust stdlib](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates).
 
 You should always use `env!("CARGO_BIN_EXE_<name>")` to determine the path to
 the binary of your crate. Do not use relative paths like `target/release/my-foo`
@@ -65,7 +65,9 @@ presents you with something like the following:
   L2 Hits:          <b>            734</b>|N/A             (<span style="color:#555">*********</span>)
   RAM Hits:         <b>           4096</b>|N/A             (<span style="color:#555">*********</span>)
   Total read+write: <b>         462200</b>|N/A             (<span style="color:#555">*********</span>)
-  Estimated Cycles: <b>         604400</b>|N/A             (<span style="color:#555">*********</span>)</code></pre>
+  Estimated Cycles: <b>         604400</b>|N/A             (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 As opposed to library benchmarks, binary benchmarks have access to a [low-level
 api](./low_level.md). Here, pretty much the same as the above high-level usage

--- a/docs/src/benchmarks/library_benchmarks/compare_by_id.md
+++ b/docs/src/benchmarks/library_benchmarks/compare_by_id.md
@@ -108,7 +108,9 @@ Here's the benchmark output of the above example to see what is happening:
   L2 Hits:          <b>              1</b>|1               (<span style="color:#555">No change</span>)
   RAM Hits:         <b>              4</b>|4               (<span style="color:#555">No change</span>)
   Total read+write: <b>            179</b>|209             (<b><span style="color:#42c142">-14.3541%</span></b>) [<b><span style="color:#42c142">-1.16760x</span></b>]
-  Estimated Cycles: <b>            319</b>|349             (<b><span style="color:#42c142">-8.59599%</span></b>) [<b><span style="color:#42c142">-1.09404x</span></b>]</code></pre>
+  Estimated Cycles: <b>            319</b>|349             (<b><span style="color:#42c142">-8.59599%</span></b>) [<b><span style="color:#42c142">-1.09404x</span></b>]
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 6 without regressions; 0 regressed; 6 benchmarks finished in 1.58123s</code></pre>
 
 The procedure of the comparison algorithm:
 

--- a/docs/src/benchmarks/library_benchmarks/configuration/output_format.md
+++ b/docs/src/benchmarks/library_benchmarks/configuration/output_format.md
@@ -1,0 +1,80 @@
+<!-- markdownlint-disable MD041 MD033 -->
+
+# Output Format
+
+The Iai-callgrind output can be customized with [command-line
+arguments](../../../cli_and_env/output.md). But, the fine-grained terminal
+output format is adjusted in the benchmark itself. For example [truncating
+the description][`OutputFormat.truncate_description`], [showing a
+grid][`OutputFormat.show_grid`], .... Please read the [docs][`OutputFormat`] for
+further details.
+
+However, I want to point out the possibility to show the cache misses in the
+Iai-Callgrind output in the following section.
+
+## Showing cache misses
+
+A default Iai-Callgrind benchmark run displays the following metrics:
+
+<pre><code class="hljs"><span style="color:#0A0">test_lib_bench_readme_example_fibonacci::bench_fibonacci_group::bench_fibonacci</span> <span style="color:#0AA">short</span><span style="color:#0AA">:</span><b><span style="color:#00A">10</span></b>
+<span style="color:#555">  </span>Instructions:                        <b>1734</b>|1734                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L1 Hits:                             <b>2359</b>|2359                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L2 Hits:                                <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>RAM Hits:                               <b>3</b>|3                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Total read+write:                    <b>2362</b>|2362                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Estimated Cycles:                    <b>2464</b>|2464                 (<span style="color:#555">No change</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
+
+The cache and ram hits, `Total read+write` and `Estimated Cycles` are actually
+not part of the original collected callgrind metrics but calculated from them.
+If you want to see the cache misses nonetheless, you can achieve this by
+specifying the [OutputFormat][`OutputFormat`] for example at top-level for all
+benchmarks in the same file in the `main!` macro:
+
+```rust
+# extern crate iai_callgrind;
+# use iai_callgrind::{library_benchmark, library_benchmark_group};
+use iai_callgrind::{main, LibraryBenchmarkConfig, OutputFormat, CallgrindMetrics};
+
+# #[library_benchmark] fn bench() {}
+# library_benchmark_group!(name = my_group; benchmarks = bench);
+# fn main() {
+main!(
+    config = LibraryBenchmarkConfig::default()
+        .output_format(OutputFormat::default()
+            callgrind([CallgrindMetrics::All])
+        );
+    library_benchmark_groups = my_group
+);
+# }
+```
+
+The Iai-Callgrind output will then show all cache metrics:
+
+<pre><code class="hljs"><span style="color:#0A0">test_lib_bench_readme_example_fibonacci::my_group::bench_fibonacci</span> <span style="color:#0AA">short</span><span style="color:#0AA">:</span><b><span style="color:#00A">10</span></b>
+<span style="color:#555">  </span>Instructions:                        <b>1734</b>|1734                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Dr:                                   <b>270</b>|270                  (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Dw:                                   <b>358</b>|358                  (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>I1mr:                                   <b>3</b>|3                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>D1mr:                                   <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>D1mw:                                   <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>ILmr:                                   <b>3</b>|3                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>DLmr:                                   <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>DLmw:                                   <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L1 Hits:                             <b>2359</b>|2359                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L2 Hits:                                <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>RAM Hits:                               <b>3</b>|3                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Total read+write:                    <b>2362</b>|2362                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Estimated Cycles:                    <b>2464</b>|2464                 (<span style="color:#555">No change</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49301s</code></pre>
+
+To take it further, the callgrind output format can be fully customized showing
+only the metrics you're interested in and in any order. This is described in
+full detail in the [docs][`OutputFormat.callgrind`].
+
+[`OutputFormat`]: https://docs.rs/iai-callgrind/0.14.2/iai_callgrind/struct.OutputFormat.html
+[`OutputFormat.callgrind`]: https://docs.rs/iai-callgrind/0.14.2/iai_callgrind/struct.OutputFormat.html#method.callgrind
+[`OutputFormat.show_grid`]: https://docs.rs/iai-callgrind/0.14.2/iai_callgrind/struct.OutputFormat.html#method.show_grid
+[`OutputFormat.truncate_description`]: https://docs.rs/iai-callgrind/0.14.2/iai_callgrind/struct.OutputFormat.html#method.truncate_description

--- a/docs/src/benchmarks/library_benchmarks/configuration/output_format.md
+++ b/docs/src/benchmarks/library_benchmarks/configuration/output_format.md
@@ -43,7 +43,7 @@ use iai_callgrind::{main, LibraryBenchmarkConfig, OutputFormat, CallgrindMetrics
 main!(
     config = LibraryBenchmarkConfig::default()
         .output_format(OutputFormat::default()
-            callgrind([CallgrindMetrics::All])
+            .callgrind([CallgrindMetrics::All])
         );
     library_benchmark_groups = my_group
 );

--- a/docs/src/benchmarks/library_benchmarks/important.md
+++ b/docs/src/benchmarks/library_benchmarks/important.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 MD033 -->
+
 # Important default behaviour
 
 The environment variables are cleared before running a library benchmark. Have a
@@ -14,7 +16,8 @@ are:
 
 The thread and subprocess specific valgrind options enable tracing threads and
 subprocesses basically but there's usually some additional configuration
-necessary to trace the metrics of threads and subprocesses.
+necessary to [trace the metrics of threads and
+subprocesses](./threads_and_subprocesses.md).
 
 As show in the table above, the benchmarks run with cache simulation switched
 on. This adds run time. If you don't need the cache metrics and estimation of
@@ -51,3 +54,22 @@ main!(
 );
 # }
 ```
+
+<!-- TODO: ALSO IN library_benchmarks -->
+<!-- TODO: Update all example outputs with the summary -->
+<!-- TODO: Talk about --nosummary in cli_and_env -->
+Iai-Callgrind reports the cache hits and an estimation of cpu cycles:
+
+<pre><code class="hljs"><span style="color:#0A0">test_lib_bench_readme_example_fibonacci::bench_fibonacci_group::bench_fibonacci</span> <span style="color:#0AA">short</span><span style="color:#0AA">:</span><b><span style="color:#00A">10</span></b>
+<span style="color:#555">  </span>Instructions:                        <b>1734</b>|1734                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L1 Hits:                             <b>2359</b>|2359                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>L2 Hits:                                <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>RAM Hits:                               <b>3</b>|3                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Total read+write:                    <b>2362</b>|2362                 (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>Estimated Cycles:                    <b>2464</b>|2464                 (<span style="color:#555">No change</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
+
+If you prefer cache misses over cache hits or just want both metrics displayed
+you can fully customize the [callgrind output
+format](../library_benchmarks/configuration/output_format.md).

--- a/docs/src/benchmarks/library_benchmarks/important.md
+++ b/docs/src/benchmarks/library_benchmarks/important.md
@@ -55,9 +55,6 @@ main!(
 # }
 ```
 
-<!-- TODO: ALSO IN library_benchmarks -->
-<!-- TODO: Update all example outputs with the summary -->
-<!-- TODO: Talk about --nosummary in cli_and_env -->
 Iai-Callgrind reports the cache hits and an estimation of cpu cycles:
 
 <pre><code class="hljs"><span style="color:#0A0">test_lib_bench_readme_example_fibonacci::bench_fibonacci_group::bench_fibonacci</span> <span style="color:#0AA">short</span><span style="color:#0AA">:</span><b><span style="color:#00A">10</span></b>

--- a/docs/src/benchmarks/library_benchmarks/quickstart.md
+++ b/docs/src/benchmarks/library_benchmarks/quickstart.md
@@ -67,7 +67,9 @@ and should see something like the below
   L2 Hits:          <b>              2</b>|N/A             (<span style="color:#555">*********</span>)
   RAM Hits:         <b>              4</b>|N/A             (<span style="color:#555">*********</span>)
   Total read+write: <b>       35638622</b>|N/A             (<span style="color:#555">*********</span>)
-  Estimated Cycles: <b>       35638766</b>|N/A             (<span style="color:#555">*********</span>)</code></pre>
+  Estimated Cycles: <b>       35638766</b>|N/A             (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 2 without regressions; 0 regressed; 2 benchmarks finished in 0.49333s</code></pre>
 
 In addition, you'll find the callgrind output and the output of other valgrind
 tools in `target/iai`, if you want to investigate further with a tool like
@@ -90,4 +92,6 @@ between the current and the previous run. Say you've made change to the
   L2 Hits:          <b>              2</b>|2               (<span style="color:#555">No change</span>)
   RAM Hits:         <b>              4</b>|4               (<span style="color:#555">No change</span>)
   Total read+write: <b>       22025882</b>|35638622        (<b><span style="color:#42c142">-38.1966%</span></b>) [<b><span style="color:#42c142">-1.61803x</span></b>]
-  Estimated Cycles: <b>       22026026</b>|35638766        (<b><span style="color:#42c142">-38.1964%</span></b>) [<b><span style="color:#42c142">-1.61803x</span></b>]</code></pre>
+  Estimated Cycles: <b>       22026026</b>|35638766        (<b><span style="color:#42c142">-38.1964%</span></b>) [<b><span style="color:#42c142">-1.61803x</span></b>]
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 2 without regressions; 0 regressed; 2 benchmarks finished in 0.49333s</code></pre>

--- a/docs/src/benchmarks/library_benchmarks/setup_and_teardown.md
+++ b/docs/src/benchmarks/library_benchmarks/setup_and_teardown.md
@@ -63,7 +63,9 @@ result in the benchmark output like below.
   L2 Hits:          <b>              2</b>|N/A             (<span style="color:#555">*********</span>)
   RAM Hits:         <b>             11</b>|N/A             (<span style="color:#555">*********</span>)
   Total read+write: <b>        2507946</b>|N/A             (<span style="color:#555">*********</span>)
-  Estimated Cycles: <b>        2508328</b>|N/A             (<span style="color:#555">*********</span>)</code></pre>
+  Estimated Cycles: <b>        2508328</b>|N/A             (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 The description in the headline contains `open_file("path/to/file")`, your setup
 function `open_file` with the value of the parameter it is called with.
@@ -171,7 +173,9 @@ bytes read: 25078
   L2 Hits:          <b>              2</b>|N/A             (<span style="color:#555">*********</span>)
   RAM Hits:         <b>             13</b>|N/A             (<span style="color:#555">*********</span>)
   Total read+write: <b>        2507946</b>|N/A             (<span style="color:#555">*********</span>)
-  Estimated Cycles: <b>        2508396</b>|N/A             (<span style="color:#555">*********</span>)</code></pre>
+  Estimated Cycles: <b>        2508396</b>|N/A             (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 The output of the `teardown` function is now visible in the benchmark output
 above the `- end of stdout/stderr` line.

--- a/docs/src/benchmarks/library_benchmarks/threads_and_subprocesses.md
+++ b/docs/src/benchmarks/library_benchmarks/threads_and_subprocesses.md
@@ -166,7 +166,9 @@ terminal output:
 <span style="color:#555">  </span>L2 Hits:                              <b>341</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>539</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                   <b>67233</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                   <b>86923</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                   <b>86923</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 1.19222s</code></pre>
 
 As you can see, the counts for the threads `2` and `3` (our spawned threads) are
 all zero.
@@ -237,7 +239,9 @@ threads are still zero:
 <span style="color:#555">  </span>L2 Hits:                              <b>343</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>538</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                   <b>67312</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                   <b>86976</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                   <b>86976</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 1.19222s</code></pre>
 
 Just to show what would happen if the compiler does not inline the `find_primes`
 method, we temporarily annotate it with `#[inline(never)]`:
@@ -284,7 +288,9 @@ Now, running the benchmark does show the desired metrics:
 <span style="color:#555">  </span>L2 Hits:                              <b>359</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>854</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                 <b>6326868</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                 <b>6357340</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                 <b>6357340</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 1.19222s</code></pre>
 
 But, annotating functions with `#[inline(never)]` in production code is usually
 not an option and preventing the compiler from doing its job is not the
@@ -354,7 +360,9 @@ from `27372` to `404425`):
 <span style="color:#555">  </span>L2 Hits:                             <b>1419</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                            <b>5466</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                 <b>6853187</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                 <b>7044707</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                 <b>7044707</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 Additionally, expect a lot of metric changes if the benchmarks itself are
 changed. However, if the metrics of the main thread are not significant compared
@@ -438,7 +446,9 @@ threads:
 <span style="color:#555">  </span>L2 Hits:                              <b>358</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>853</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                 <b>6326783</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                 <b>6357217</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                 <b>6357217</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 Using the client request toggles is very flexible since you can put the
 `iai_callgrind::client_requests::callgrind::toggle_collect` instructions
@@ -508,7 +518,9 @@ Altogether, running the benchmark will show:
 <span style="color:#555">  </span>L2 Hits:                               <b>15</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>318</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                 <b>6259550</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                 <b>6270422</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                 <b>6270422</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 ## Multi-process applications
 
@@ -631,7 +643,9 @@ output:
 <span style="color:#555">  </span>L2 Hits:                               <b>17</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>186</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                    <b>6305</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                   <b>12697</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                   <b>12697</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 As expected, the `cat` subprocess is not measured and the metrics are zero for
 the same reasons as the initial measurement of threads.
@@ -698,7 +712,9 @@ producing the desired output
 <span style="color:#555">  </span>L2 Hits:                               <b>26</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>354</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                   <b>12067</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                   <b>24207</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                   <b>24207</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 ### Measuring subprocesses using client requests
 
@@ -787,7 +803,9 @@ Now, running the benchmark shows
 <span style="color:#555">  </span>L2 Hits:                               <b>25</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>RAM Hits:                             <b>324</b>|N/A                  (<span style="color:#555">*********</span>)
 <span style="color:#555">  </span>Total read+write:                    <b>9857</b>|N/A                  (<span style="color:#555">*********</span>)
-<span style="color:#555">  </span>Estimated Cycles:                   <b>20973</b>|N/A                  (<span style="color:#555">*********</span>)</code></pre>
+<span style="color:#555">  </span>Estimated Cycles:                   <b>20973</b>|N/A                  (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 As expected, the metrics for the `cat` binary are a little bit lower since we
 skipped measuring the parsing of the command-line arguments.

--- a/docs/src/cli_and_env/baselines.md
+++ b/docs/src/cli_and_env/baselines.md
@@ -46,7 +46,9 @@ prints something like that with an additional line `Baselines` in the output.
   L2 Hits:          <b>              1</b>|N/A             (<span style="color:#555">*********</span>)
   RAM Hits:         <b>              6</b>|N/A             (<span style="color:#555">*********</span>)
   Total read+write: <b>            381</b>|N/A             (<span style="color:#555">*********</span>)
-  Estimated Cycles: <b>            589</b>|N/A             (<span style="color:#555">*********</span>)</code></pre>
+  Estimated Cycles: <b>            589</b>|N/A             (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 After you've made some changes to your code, running
 
@@ -63,4 +65,6 @@ prints something like the following:
   L2 Hits:          <b>              1</b>|1               (<span style="color:#555">No change</span>)
   RAM Hits:         <b>              6</b>|6               (<span style="color:#555">No change</span>)
   Total read+write: <b>            294</b>|381             (<b><span style="color:#42c142">-22.8346%</span></b>) [<b><span style="color:#42c142">-1.29592x</span></b>]
-  Estimated Cycles: <b>            502</b>|589             (<b><span style="color:#42c142">-14.7708%</span></b>) [<b><span style="color:#42c142">-1.17331x</span></b>]</code></pre>
+  Estimated Cycles: <b>            502</b>|589             (<b><span style="color:#42c142">-14.7708%</span></b>) [<b><span style="color:#42c142">-1.17331x</span></b>]
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>

--- a/docs/src/cli_and_env/output/terminal_output.md
+++ b/docs/src/cli_and_env/output/terminal_output.md
@@ -71,7 +71,9 @@ Error output during teardown: 20
   L2 Hits:          <b>              5</b>|N/A             (<span style="color:#555">*********</span>)
   RAM Hits:         <b>             66</b>|N/A             (<span style="color:#555">*********</span>)
   Total read+write: <b>           1264</b>|N/A             (<span style="color:#555">*********</span>)
-  Estimated Cycles: <b>           3528</b>|N/A             (<span style="color:#555">*********</span>)</code></pre>
+  Estimated Cycles: <b>           3528</b>|N/A             (<span style="color:#555">*********</span>)
+
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.49333s</code></pre>
 
 Everything between the headline and the `- end of stdout/stderr` line is output
 from your benchmark. The `- end of stdout/stderr` line changes depending on the

--- a/docs/src/regressions.md
+++ b/docs/src/regressions.md
@@ -9,6 +9,11 @@ perform default regression checks, and you have to opt-in with a
 `BinaryBenchmarkConfig` or at a global level with [Command-line arguments or
 Environment variables](./cli_and_env/basics.md).
 
+Note that [comparing baselines](./cli_and_env/baselines.md) also detects
+performance regressions. This can be useful, for example, when setting up
+Iai-Callgrind in the [CI](./installation/iai_callgrind.md#in-the-github-ci) to
+cause a PR to fail when comparing to the main branch.
+
 ## Define a performance regression
 
 A performance regression check consists of an `EventKind` and a percentage. If

--- a/docs/src/regressions.md
+++ b/docs/src/regressions.md
@@ -31,8 +31,9 @@ use iai_callgrind::{
 use std::hint::black_box;
 
 #[library_benchmark]
-fn bench_library() -> Vec<i32> {
-    black_box(my_lib::bubble_sort(vec![3, 2, 1]))
+#[bench::worst_case(vec![3, 2, 1])]
+fn bench_library(data: Vec<i32>) -> Vec<i32> {
+    black_box(my_lib::bubble_sort(data))
 }
 
 library_benchmark_group!(name = my_group; benchmarks = bench_library);
@@ -57,32 +58,39 @@ for further configuration options.
 
 Running the benchmark from above the first time results in the following output:
 
-<pre><code class="hljs"><span style="color:#0A0">my_benchmark::my_group::bench_library</span>
-  Instructions:     <b>            215</b>|N/A             (<span style="color:#555">*********</span>)
-  L1 Hits:          <b>            288</b>|N/A             (<span style="color:#555">*********</span>)
-  L2 Hits:          <b>              0</b>|N/A             (<span style="color:#555">*********</span>)
-  RAM Hits:         <b>              7</b>|N/A             (<span style="color:#555">*********</span>)
-  Total read+write: <b>            295</b>|N/A             (<span style="color:#555">*********</span>)
-  Estimated Cycles: <b>            533</b>|N/A             (<span style="color:#555">*********</span>)</code></pre>
+<pre><code class="hljs"><span style="color:#0A0">lib_bench_regression::my_group::bench_library</span> <span style="color:#0AA">worst_case</span><span style="color:#0AA">:</span><b><span style="color:#00A">vec! [3, 2, 1]</span></b>
+<span style="color:#555">  </span>Instructions:                         <b>152</b>|N/A                  (<span style="color:#555">*********</span>)
+<span style="color:#555">  </span>L1 Hits:                              <b>201</b>|N/A                  (<span style="color:#555">*********</span>)
+<span style="color:#555">  </span>L2 Hits:                                <b>0</b>|N/A                  (<span style="color:#555">*********</span>)
+<span style="color:#555">  </span>RAM Hits:                               <b>5</b>|N/A                  (<span style="color:#555">*********</span>)
+<span style="color:#555">  </span>Total read+write:                     <b>206</b>|N/A                  (<span style="color:#555">*********</span>)
+<span style="color:#555">  </span>Estimated Cycles:                     <b>376</b>|N/A                  (<span style="color:#555">*********</span>)
 
-Let's assume there's a change in `my_lib::bubble_sort` which has increased the
-instruction counts, then running the benchmark again results in an output
-something similar to this:
+Iai-Callgrind result: <b><span style="color:#0A0">Ok</span></b>. 1 without regressions; 0 regressed; 1 benchmarks finished in 0.14477s</code></pre>
 
-<pre><code class="hljs"><span style="color:#0A0">my_benchmark::my_group::bench_library</span>
-  Instructions:     <b>            281</b>|215             (<b><span style="color:#F55">+30.6977%</span></b>) [<b><span style="color:#F55">+1.30698x</span></b>]
-  L1 Hits:          <b>            374</b>|288             (<b><span style="color:#F55">+29.8611%</span></b>) [<b><span style="color:#F55">+1.29861x</span></b>]
-  L2 Hits:          <b>              0</b>|0               (<span style="color:#555">No change</span>)
-  RAM Hits:         <b>              8</b>|7               (<b><span style="color:#F55">+14.2857%</span></b>) [<b><span style="color:#F55">+1.14286x</span></b>]
-  Total read+write: <b>            382</b>|295             (<b><span style="color:#F55">+29.4915%</span></b>) [<b><span style="color:#F55">+1.29492x</span></b>]
-  Estimated Cycles: <b>            654</b>|533             (<b><span style="color:#F55">+22.7017%</span></b>) [<b><span style="color:#F55">+1.22702x</span></b>]
-Performance has <b><span style="color:#F55">regressed</span></b>: <b>Instructions</b> (281 > 215) regressed by <b><span style="color:#F55">+30.6977%</span></b> (><span style="color:#555">+5.00000</span>)
-iai_callgrind_runner: <b><span style="color:#A00">Error</span></b>: Performance has regressed.
-error: bench failed, to rerun pass `-p the-crate --bench my_benchmark`
+Let's assume there's a change in `my_lib::bubble_sort` with a negative impact on
+the performance, then running the benchmark again results in an output something
+similar to this:
+
+<pre><code class="hljs"><span style="color:#0A0">lib_bench_regression::my_group::bench_library</span> <span style="color:#0AA">worst_case</span><span style="color:#0AA">:</span><b><span style="color:#00A">vec! [3, 2, 1]</span></b>
+<span style="color:#555">  </span>Instructions:                         <b>264</b>|152                  (<b><span style="color:#F55">+73.6842%</span></b>) [<b><span style="color:#F55">+1.73684x</span></b>]
+<span style="color:#555">  </span>L1 Hits:                              <b>341</b>|201                  (<b><span style="color:#F55">+69.6517%</span></b>) [<b><span style="color:#F55">+1.69652x</span></b>]
+<span style="color:#555">  </span>L2 Hits:                                <b>0</b>|0                    (<span style="color:#555">No change</span>)
+<span style="color:#555">  </span>RAM Hits:                               <b>6</b>|5                    (<b><span style="color:#F55">+20.0000%</span></b>) [<b><span style="color:#F55">+1.20000x</span></b>]
+<span style="color:#555">  </span>Total read+write:                     <b>347</b>|206                  (<b><span style="color:#F55">+68.4466%</span></b>) [<b><span style="color:#F55">+1.68447x</span></b>]
+<span style="color:#555">  </span>Estimated Cycles:                     <b>551</b>|376                  (<b><span style="color:#F55">+46.5426%</span></b>) [<b><span style="color:#F55">+1.46543x</span></b>]
+Performance has <b><span style="color:#F55">regressed</span></b>: <b>Instructions</b> (152 -> <b>264</b>) regressed by <b><span style="color:#F55">+73.6842%</span></b> (><span style="color:#555">+5.00000%</span>)
+
+Regressions:
+
+  <span style="color:#0A0">lib_bench_regression::my_group::bench_library</span>:
+    <b>Instructions</b> (152 -> <b>264</b>): <b><span style="color:#F55">+73.6842</span></b><b><span style="color:#F55">%</span></b> exceeds limit of <span style="color:#555">+5.00000</span><span style="color:#555">%</span>
+
+Iai-Callgrind result: <b><span style="color:#F55">Regressed</span></b>. 0 without regressions; 1 regressed; 1 benchmarks finished in 0.14849s
+error: bench failed, to rerun pass `-p benchmark-tests --bench lib_bench_regression`
 
 Caused by:
-  process didn't exit successfully: `/path/to/your/project/target/release/deps/my_benchmark-a9b36fec444944bd --bench` (exit status: 1)
-error: Recipe `bench-test` failed on line 175 with exit code 1</code></pre>
+  process didn't exit successfully: `/home/lenny/workspace/programming/iai-callgrind/target/release/deps/lib_bench_regression-98382b533bca8f56 --bench` (exit status: 3)</code></pre>
 
 ## Which event to choose to measure performance regressions?
 


### PR DESCRIPTION
* Update the code examples with the new summary line and regression stats
* Add section with the (callgrind) output format and give introductory examples on how to show cache misses
* Crosslink to CI in Regressions chapter and Comparison with baselines (#308) 