### PR TITLE
doc(guide): Fix valgrind installation instructions for Alpine Linux

### DIFF
--- a/docs/src/installation/prerequisites.md
+++ b/docs/src/installation/prerequisites.md
@@ -60,7 +60,7 @@ in your `$PATH` so that Iai-callgrind can find it.
 #### Alpine Linux
 
 ```bash
-apk add just
+apk add valgrind
 ```
 
 #### Arch Linux


### PR DESCRIPTION
Just fixing a typo I noticed when reading the guide.