### PR TITLE
Fix version in summary

### DIFF
--- a/.bumpversion/summary-schema.toml
+++ b/.bumpversion/summary-schema.toml
@@ -1,0 +1,15 @@
+[tool.bumpversion]
+current_version = "4"
+commit = false
+parse = "(?P<major>\\d+)"
+serialize = ["{major}"]
+
+[[tool.bumpversion.files]]
+filename = "iai-callgrind-runner/src/runner/summary.rs"
+search = "const SCHEMA_VERSION: &str = \"{current_version}\";"
+replace = "const SCHEMA_VERSION: &str = \"{new_version}\";"
+
+[[tool.bumpversion.files]]
+filename = "benchmark-tests/src/bench.rs"
+search = "const SCHEMA_VERSION: &str = \"{current_version}\";"
+replace = "const SCHEMA_VERSION: &str = \"{new_version}\";"

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -29,6 +29,9 @@ const TEMPLATE_CONTENT: &str = r#"fn main() {
     panic!("should be replaced by a rendered template");
 }
 "#;
+const SCHEMA_PATH: &str = "iai-callgrind-runner/schemas";
+const SCHEMA_VERSION: &str = "4";
+
 static TEMPLATE_DATA: OnceCell<HashMap<String, minijinja::Value>> = OnceCell::new();
 
 // The regex patterns working on the `stdout` must not include the indentation. The indentation can
@@ -766,7 +769,8 @@ impl BenchmarkRunner {
             File::open(
                 self.metadata
                     .workspace_root
-                    .join("iai-callgrind-runner/schemas/summary.v3.schema.json"),
+                    .join(SCHEMA_PATH)
+                    .join(format!("summary.v{SCHEMA_VERSION}.schema.json")),
             )
             .unwrap(),
         )
@@ -870,6 +874,15 @@ impl ExpectedRun {
                     print_error(format!("{}: Validation error: {error}", summary.display()))
                 }
             }
+            let (_, value) = instance
+                .as_object()
+                .unwrap()
+                .get_key_value("version")
+                .unwrap();
+            assert_eq!(
+                value, SCHEMA_VERSION,
+                "summary json schema version mismatch"
+            );
         }
 
         assert!(

--- a/iai-callgrind-runner/src/runner/summary.rs
+++ b/iai-callgrind-runner/src/runner/summary.rs
@@ -26,6 +26,8 @@ use crate::util::{factor_diff, make_absolute, percentage_diff, EitherOrBoth};
 
 pub type RegressionMetrics<T> = (T, u64, u64, f64, f64);
 
+pub const SCHEMA_VERSION: &str = "4";
+
 /// A `Baseline` depending on the [`BaselineKind`] which points to the corresponding path
 ///
 /// This baseline is used for comparisons with the new output of valgrind tools.
@@ -370,7 +372,7 @@ impl BenchmarkSummary {
         baselines: Baselines,
     ) -> Self {
         Self {
-            version: "4".to_owned(),
+            version: SCHEMA_VERSION.to_owned(),
             kind,
             benchmark_file: make_absolute(&project_root, benchmark_file),
             benchmark_exe: make_absolute(&project_root, benchmark_exe),

--- a/iai-callgrind-runner/src/runner/summary.rs
+++ b/iai-callgrind-runner/src/runner/summary.rs
@@ -370,7 +370,7 @@ impl BenchmarkSummary {
         baselines: Baselines,
     ) -> Self {
         Self {
-            version: "3".to_owned(),
+            version: "4".to_owned(),
             kind,
             benchmark_file: make_absolute(&project_root, benchmark_file),
             benchmark_exe: make_absolute(&project_root, benchmark_exe),


### PR DESCRIPTION
The version in the generated `summary.json` and json output was still "3" instead of "4". This pr also adds a bump version file to automate future version bumps of the summary.