### PR TITLE
feat(baselines): Print baselines with same name with (old) suffix 

### DIFF
--- a/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/expected_stdout.2
+++ b/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/expected_stdout.2
@@ -1,5 +1,5 @@
 test_bin_bench_main_and_group_setup_and_teardown::simple_group_with_setup::simple_bench () -> target/release/read-file <__ABS_PATH__>/iai-callgrind....
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -7,7 +7,7 @@ test_bin_bench_main_and_group_setup_and_teardown::simple_group_with_setup::simpl
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_main_and_group_setup_and_teardown::simple_group_with_setup::check_file_exists () -> target/release/file-exists <__ABS_PATH__>/iai-callgrin...
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -15,7 +15,7 @@ test_bin_bench_main_and_group_setup_and_teardown::simple_group_with_setup::check
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_main_and_group_setup_and_teardown::check_group::check_file_not_exists () -> target/release/file-exists <__ABS_PATH__>/iai-callgrin...
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_bin_bench/setup_and_teardown/expected_stdout.2
+++ b/benchmark-tests/benches/test_bin_bench/setup_and_teardown/expected_stdout.2
@@ -1,5 +1,5 @@
 test_bin_bench_setup_and_teardown::bench_group::bench_just_binary_benchmark_attribute () -> target/release/echo 1
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -7,7 +7,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_just_binary_benchmark_attr
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::simple_bench setup_with_args_parameter:() -> target/release/echo 2
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -15,7 +15,7 @@ test_bin_bench_setup_and_teardown::bench_group::simple_bench setup_with_args_par
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::simple_bench setup_no_args_parameter:() -> target/release/echo 2
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -23,7 +23,7 @@ test_bin_bench_setup_and_teardown::bench_group::simple_bench setup_no_args_param
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_only_setup setup_with_one_argument:(3) -> target/release/echo 3
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -31,7 +31,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_only_setup setup_with_one_
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_only_setup setup_first_then_args:(6) -> target/release/echo 6
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -39,7 +39,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_only_setup setup_first_the
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_only_setup setup_in_module:(24) -> target/release/echo 24
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -47,7 +47,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_only_setup setup_in_module
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_only_teardown teardown_with_one_argument:(2, 3, 5) -> target/release/echo 2 3 5
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -55,7 +55,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_only_teardown teardown_wit
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_only_teardown teardown_first_then_args:(4, 6, 10) -> target/release/echo 4 6 10
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -63,7 +63,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_only_teardown teardown_fir
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_only_teardown teardown_in_module:(8, 12, 20) -> target/release/echo 8 12 20
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -71,7 +71,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_only_teardown teardown_in_
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_setup_and_teardown setup_first_then_teardown:(2) -> target/release/echo 2
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -79,7 +79,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_setup_and_teardown setup_f
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_setup_and_teardown teardown_first_then_setup:(3) -> target/release/echo 3
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -87,7 +87,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_setup_and_teardown teardow
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown no_overwrite:(1) -> target/release/echo 1
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -95,7 +95,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown 
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown overwrite_teardown:(2) -> target/release/echo 2
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -103,7 +103,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown 
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown overwrite_setup:(3) -> target/release/echo 3
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -111,7 +111,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown 
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown overwrite_setup_and_teardown:(4) -> target/release/echo 4
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -119,7 +119,7 @@ test_bin_bench_setup_and_teardown::bench_group::bench_global_setup_and_teardown 
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_setup_last no_setup:() -> target/release/echo 3
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -127,7 +127,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_setup_last no_setup:() -> ta
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_setup_last with_setup:() -> target/release/echo 6
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -135,7 +135,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_setup_last with_setup:() -> 
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_only_setup setup_with_one_argument:() -> target/release/echo 3
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -143,7 +143,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_only_setup setup_with_one_ar
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_only_setup setup_in_module:() -> target/release/echo 6
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -151,7 +151,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_only_setup setup_in_module:(
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_only_teardown teardown_with_one_argument:() -> target/release/echo 10
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -159,7 +159,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_only_teardown teardown_with_
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_only_teardown teardown_in_module:() -> target/release/echo 40
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -167,7 +167,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_only_teardown teardown_in_mo
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_setup_and_teardown setup_first_then_teardown:() -> target/release/echo 2
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -175,7 +175,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_setup_and_teardown setup_fir
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_setup_and_teardown teardown_first_then_setup:() -> target/release/echo 3
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -183,7 +183,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_setup_and_teardown teardown_
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown no_overwrite:() -> target/release/echo 1
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -191,7 +191,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown no
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown overwrite_teardown:() -> target/release/echo 2
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -199,7 +199,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown ov
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown overwrite_setup:() -> target/release/echo 3
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -207,7 +207,7 @@ test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown ov
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_bin_bench_setup_and_teardown::low_level::bench_global_setup_and_teardown overwrite_setup_and_teardown:() -> target/release/echo 4
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.2
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.2
@@ -2,7 +2,7 @@ MAIN SETUP
 GROUP SETUP
 test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::simple_bench
 - end of stdout/stderr
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -11,7 +11,7 @@ test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::simpl
   Estimated Cycles:                        |N/A                  (*********)
 test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::check_file_exists
 - end of stdout/stderr
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -21,7 +21,7 @@ test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::check
 GROUP TEARDOWN
 test_lib_bench_main_and_group_setup_and_teardown::check_group::check_file_not_exists
 - end of stdout/stderr
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -31,7 +31,7 @@ test_lib_bench_main_and_group_setup_and_teardown::check_group::check_file_not_ex
 GROUP SETUP
 test_lib_bench_main_and_group_setup_and_teardown::group_only_setup::delete_file_bench
 - end of stdout/stderr
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -40,7 +40,7 @@ test_lib_bench_main_and_group_setup_and_teardown::group_only_setup::delete_file_
   Estimated Cycles:                        |N/A                  (*********)
 test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_file_bench
 - end of stdout/stderr
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.3
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/expected_stdout.3
@@ -1,5 +1,5 @@
 test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::simple_bench
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -7,7 +7,7 @@ test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::simpl
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::check_file_exists
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -15,7 +15,7 @@ test_lib_bench_main_and_group_setup_and_teardown::simple_group_with_setup::check
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_lib_bench_main_and_group_setup_and_teardown::check_group::check_file_not_exists
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -23,7 +23,7 @@ test_lib_bench_main_and_group_setup_and_teardown::check_group::check_file_not_ex
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_lib_bench_main_and_group_setup_and_teardown::group_only_setup::delete_file_bench
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -31,7 +31,7 @@ test_lib_bench_main_and_group_setup_and_teardown::group_only_setup::delete_file_
   Total read+write:                        |                     (No change)
   Estimated Cycles:                        |                     (         )
 test_lib_bench_main_and_group_setup_and_teardown::group_only_teardown::create_file_bench
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )

--- a/benchmark-tests/benches/test_lib_bench/single/expected_stdout.1
+++ b/benchmark-tests/benches/test_lib_bench/single/expected_stdout.1
@@ -1,5 +1,5 @@
 test_bench_template::bench_group::bench_bubble_sort worst_case:setup_worst_case_array(0)
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/single/expected_stdout.2
+++ b/benchmark-tests/benches/test_lib_bench/single/expected_stdout.2
@@ -1,5 +1,5 @@
 test_bench_template::bench_group::bench_bubble_sort worst_case:setup_worst_case_array(300)
-  Baselines:                            bar|bar
+  Baselines:                            bar|bar (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1d
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1d
@@ -4,7 +4,7 @@ Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -64,7 +64,7 @@ Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -132,7 +132,7 @@ Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -281,7 +281,7 @@ Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -438,7 +438,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -498,7 +498,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                        default|default
+  Baselines:                        default|default (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1e
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1e
@@ -4,7 +4,7 @@ Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -64,7 +64,7 @@ Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -132,7 +132,7 @@ Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -281,7 +281,7 @@ Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -438,7 +438,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)
@@ -498,7 +498,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |N/A
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |N/A                  (*********)
   L1 Hits:                                 |N/A                  (*********)
   LL Hits:                                 |N/A                  (*********)

--- a/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1g
+++ b/benchmark-tests/benches/test_lib_bench/threads/expected_stdout.1g
@@ -4,7 +4,7 @@ Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -64,7 +64,7 @@ Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -132,7 +132,7 @@ Number of primes found in the range 0 to 20000: 2262
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -281,7 +281,7 @@ Number of primes found in the range 0 to 30000: 3245
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -438,7 +438,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )
@@ -498,7 +498,7 @@ thread in thread: Number of primes found in the range 0 to 10000: 1229
 - end of stdout/stderr
   ## pid: <__PID__> thread: 1 part: 1      |pid: <__PID__> thread: 1 part: 1
   Command: <__COMMAND__>
-  Baselines:                            foo|foo
+  Baselines:                            foo|foo (old)
   Instructions:                            |                     (No change)
   L1 Hits:                                 |                     (         )
   LL Hits:                                 |                     (         )

--- a/iai-callgrind-runner/src/runner/format.rs
+++ b/iai-callgrind-runner/src/runner/format.rs
@@ -696,11 +696,15 @@ impl VerticalFormatter {
     fn format_baseline(&mut self, baselines: &Baselines) {
         match baselines {
             (None, None) => {}
+            (Some(left), Some(right)) if left == right => {
+                let right = format!("{right} (old)");
+                self.write_field("Baselines:", &EitherOrBoth::Both(left, &right), None, false);
+            }
             _ => {
                 self.write_field(
                     "Baselines:",
                     &EitherOrBoth::try_from(baselines.clone())
-                        .expect("At least on baseline should be present")
+                        .expect("At least one baseline should be present")
                         .as_ref()
                         .map(String::as_str),
                     None,


### PR DESCRIPTION
This happens especially with `--save-baseline=...`, so instead of

```
icount::icount_bench_yn_group::icount_bench_yn logspace:setup_yn()
  Baselines:                        default|default
  Instructions:                    24636546|24636546             (No change)
```

baselines are printed with `(old)` if the names are equal

```
icount::icount_bench_yn_group::icount_bench_yn logspace:setup_yn()
  Baselines:                        default|default (old)
  Instructions:                    24636546|24636546             (No change)
```

Related #338