### PR TITLE
Refactor `runner::args`

### DIFF
--- a/iai-callgrind-runner/src/runner/args.rs
+++ b/iai-callgrind-runner/src/runner/args.rs
@@ -255,7 +255,7 @@ pub struct CommandLineArgs {
     /// This is a `,`-separated list of cachegrind metric groups and event kinds which are allowed
     /// to appear in the terminal output of cachegrind.
     ///
-    /// See `--callgrind-limits` for more details and
+    /// See `--callgrind-metrics` for more details and
     /// <https://docs.rs/iai-callgrind/latest/iai_callgrind/enum.CachegrindMetrics.html>
     /// respectively
     /// <https://docs.rs/iai-callgrind/latest/iai_callgrind/enum.CachegrindMetric.html> for valid


### PR DESCRIPTION
Sort fields alphabetically and instead use clap's display order to improve the sorting of the arguments in the --help message.