### PR TITLE
Flag/ENV to show only comparisons with other benchmarks with `compare_by_id`

### DIFF
--- a/benchmark-tests/benches/test_lib_bench/compare/expected_stdout.show-only-comparison
+++ b/benchmark-tests/benches/test_lib_bench/compare/expected_stdout.show-only-comparison
@@ -1,0 +1,114 @@
+test_lib_bench_compare::bubble_sort_compare_one::bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+test_lib_bench_compare::bubble_sort_compare_one::bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+test_lib_bench_compare::bubble_sort_compare_one::bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_worst_case case_3:vec! [3, 2, 1]
+  Comparison with bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_worst_case multiple_0:vec! [2, 1]
+  Comparison with bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_two::bench_bubble_sort_worst_case multiple_1:vec! [4, 3, 2, 1]
+  Comparison with bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_worst_case case_3:vec! [3, 2, 1]
+  Comparison with bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_worst_case multiple_0:vec! [2, 1]
+  Comparison with bench_bubble_sort_best_case multiple_0:vec! [1, 2]
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_worst_case multiple_1:vec! [4, 3, 2, 1]
+  Comparison with bench_bubble_sort_best_case multiple_1:vec! [1, 2, 3, 4]
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_mixed_case case_3:vec! [2, 3, 1]
+  Comparison with bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+  Comparison with bench_bubble_sort_worst_case case_3:vec! [3, 2, 1]
+  Instructions:                            |                     (+       %) [+       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (+       %) [+       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_mixed_case no_compare_multiple_0:vec! [2, 1]
+test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_mixed_case no_compare_multiple_1:vec! [2, 4, 3, 1]
+test_lib_bench_compare::bubble_sort_compare_no_id::bench_bubble_sort_no_id_1
+test_lib_bench_compare::bubble_sort_compare_no_id::bench_bubble_sort_no_id_2
+test_lib_bench_compare::bubble_sort_compare_with_dhat::bench_bubble_sort_dhat case_3:setup_worst_case_array(3)
+test_lib_bench_compare::bubble_sort_compare_with_dhat::bench_bubble_sort_dhat_other case_3:setup_best_case_array(3)
+  Comparison with bench_bubble_sort_dhat case_3:setup_worst_case_array(3)
+  ------- CALLGRIND
+  Instructions:                            |                     (+       %) [+       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (+       %) [+       x]
+  Estimated Cycles:                        |                     (         )
+  ------- DHAT
+  Total bytes:                             |                     (No change)
+  Total blocks:                            |                     (No change)
+  At t-gmax bytes:                         |                     (         )
+  At t-gmax blocks:                        |                     (         )
+  At t-end bytes:                          |                     (No change)
+  At t-end blocks:                         |                     (No change)
+  Reads bytes:                             |                     (No change)
+  Writes bytes:                            |                     (+       %) [+       x]
+test_lib_bench_compare::bubble_sort_compare_with_dhat::bench_bubble_sort_mixed_case case_3:vec! [2, 3, 1]
+  Comparison with bench_bubble_sort_dhat case_3:setup_worst_case_array(3)
+  Instructions:                            |                     (+       %) [+       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (+       %) [+       x]
+  Estimated Cycles:                        |                     (         )
+  Comparison with bench_bubble_sort_dhat_other case_3:setup_best_case_array(3)
+  Instructions:                            |                     (-       %) [-       x]
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (-       %) [-       x]
+  Estimated Cycles:                        |                     (         )
+test_lib_bench_compare::bubble_sort_compare_with_dhat::bench_bubble_sort_mixed_case no_compare_multiple_0:vec! [2, 1]
+test_lib_bench_compare::bubble_sort_compare_with_dhat::bench_bubble_sort_mixed_case no_compare_multiple_1:vec! [2, 4, 3, 1]
+
+Iai-Callgrind result: Ok. 25 without regressions; 0 regressed; 25 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_lib_bench/compare/test_lib_bench_compare.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/compare/test_lib_bench_compare.conf.yml
@@ -4,3 +4,8 @@ groups:
         expected:
           files: expected_files.1.yml
           stdout: expected_stdout.1
+  - runs:
+      - args: ["--show-only-comparison"]
+        expected:
+          files: expected_files.1.yml
+          stdout: expected_stdout.show-only-comparison

--- a/iai-callgrind-runner/src/runner/args.rs
+++ b/iai-callgrind-runner/src/runner/args.rs
@@ -868,6 +868,27 @@ pub struct CommandLineArgs {
     pub separate_targets: bool,
 
     #[rustfmt::skip]
+    /// Show only the comparison between different benchmarks when using `compare_by_id`
+    ///
+    /// If you're only interested in the comparisons between different benchmarks but not the metric
+    /// differences between the self comparisons of the new and old benchmark run, use this option.
+    /// This option is only useful if `compare_by_id` is used in the `library_benchmark_group!` or
+    /// `binary_benchmark_group!`. Note, that it does not prevent any benchmarks to be run,
+    /// especially benchmarks which are not compared to another benchmark. Such benchmarks have only
+    /// the usual benchmark headline printed.
+    #[arg(
+        long = "show-only-comparison",
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+        value_parser = BoolishValueParser::new(),
+        verbatim_doc_comment,
+        env = "IAI_CALLGRIND_SHOW_ONLY_COMPARISON",
+        display_order = 300
+    )]
+    pub show_only_comparison: Option<bool>,
+
+    #[rustfmt::skip]
     /// Show changes only when they are above the `tolerance` level
     ///
     /// If no value is specified, the default value of `0.000_009_999_999_999_999_999` is based on

--- a/iai-callgrind-runner/src/runner/format.rs
+++ b/iai-callgrind-runner/src/runner/format.rs
@@ -123,6 +123,8 @@ pub struct OutputFormat {
     pub show_grid: bool,
     /// Show intermediate metrics output or just the total
     pub show_intermediate: bool,
+    /// Show only the comparison between different benchmarks when `compare_by_id` is given
+    pub show_only_comparison: bool,
     /// Don't show differences within the tolerance margin
     pub tolerance: Option<f64>,
     /// If present truncate the description to this amount of bytes
@@ -506,12 +508,17 @@ impl OutputFormat {
         if meta.args.tolerance.is_some() {
             self.tolerance = meta.args.tolerance;
         }
+
+        if let Some(show_only_comparison) = meta.args.show_only_comparison {
+            self.show_only_comparison = show_only_comparison;
+        }
     }
 }
 
 impl Default for OutputFormat {
     fn default() -> Self {
         Self {
+            show_only_comparison: false,
             kind: OutputFormatKind::default(),
             truncate_description: Some(50),
             show_intermediate: false,
@@ -1128,7 +1135,9 @@ impl Formatter for VerticalFormatter {
         data: &ProfileData,
         is_default_tool: bool,
     ) -> Result<()> {
-        if data.has_multiple() && self.output_format.show_intermediate {
+        if self.output_format.show_only_comparison {
+            // no usual data to show
+        } else if data.has_multiple() && self.output_format.show_intermediate {
             let mut first = true;
             for part in &data.parts {
                 self.format_multiple_segment_header(&part.details);

--- a/iai-callgrind-runner/src/runner/tool/config.rs
+++ b/iai-callgrind-runner/src/runner/tool/config.rs
@@ -483,6 +483,7 @@ impl ToolConfigs {
 
     fn print_headline(&self, tool_config: &ToolConfig, output_format: &OutputFormat) {
         if output_format.is_default()
+            && !output_format.show_only_comparison
             && (self.has_multiple() || tool_config.tool != ValgrindTool::Callgrind)
         {
             let mut formatter = VerticalFormatter::new(output_format.clone());


### PR DESCRIPTION
This pr adds a command-line argument `--show-only-comparison` and env var `IAI_CALLGRIND_SHOW_ONLY_COMPARISON`. This option cancels showing the self comparisons of benchmarks and shows only the comparisons with other benchmarks when `compare_by_id` in a `library_benchmark_group` or `binary_benchmark_group` was given.

Curated example output:
         
```
test_lib_bench_compare::bubble_sort_compare_three::bench_bubble_sort_mixed_case case_3:vec! [2, 3, 1]
  Comparison with bench_bubble_sort_best_case case_3:vec! [1, 2, 3]
  Instructions:                          74|81                   (-8.64198%) [-1.09459x]
  L1 Hits:                               94|104                  (-9.61538%) [-1.10638x]
  LL Hits:                                1|1                    (No change)
  RAM Hits:                               3|4                    (-25.0000%) [-1.33333x]
  Total read+write:                      98|109                  (-10.0917%) [-1.11224x]
  Estimated Cycles:                     204|249                  (-18.0723%) [-1.22059x]
  Comparison with bench_bubble_sort_worst_case case_3:vec! [3, 2, 1]
  Instructions:                          83|81                   (+2.46914%) [+1.02469x]
  L1 Hits:                              109|104                  (+4.80769%) [+1.04808x]
  LL Hits:                                1|1                    (No change)
  RAM Hits:                               3|4                    (-25.0000%) [-1.33333x]
  Total read+write:                     113|109                  (+3.66972%) [+1.03670x]
  Estimated Cycles:                     219|249                  (-12.0482%) [-1.13699x]
test_lib_bench_compare::bubble_sort_compare_with_dhat::bench_bubble_sort_dhat case_3:setup_best_case_array(3)
  Comparison with bench_bubble_sort_dhat_other case_3:setup_worst_case_array(3)
  ------- CALLGRIND
  Instructions:                          83|75                   (+10.6667%) [+1.10667x]
  L1 Hits:                              109|95                   (+14.7368%) [+1.14737x]
  LL Hits:                                1|1                    (No change)
  RAM Hits:                               3|3                    (No change)
  Total read+write:                     113|99                   (+14.1414%) [+1.14141x]
  Estimated Cycles:                     219|205                  (+6.82927%) [+1.06829x]
  ------- DHAT
  Total bytes:                           12|12                   (No change)
  Total blocks:                           1|1                    (No change)
  At t-gmax bytes:                        0|0                    (No change)
  At t-gmax blocks:                       0|0                    (No change)
  At t-end bytes:                         0|0                    (No change)
  At t-end blocks:                        0|0                    (No change)
  Reads bytes:                           24|24                   (No change)
  Writes bytes:                          36|12                   (+200.000%) [+3.00000x]

Iai-Callgrind result: Ok. 25 without regressions; 0 regressed; 25 benchmarks finished in 4.53636s

```